### PR TITLE
Add piping input support to trace_stats script

### DIFF
--- a/traceratops/trace_stats.py
+++ b/traceratops/trace_stats.py
@@ -8,6 +8,7 @@ This script reads a chromatin trace file and computes basic statistics:
 
 import argparse
 import os
+import select
 import sys
 
 from traceratops.core.chromatin_trace_table import ChromatinTraceTable
@@ -15,8 +16,25 @@ from traceratops.core.chromatin_trace_table import ChromatinTraceTable
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--input", required=True, help="Path to the input trace file.")
+    input_group = parser.add_mutually_exclusive_group(required=True)
+    input_group.add_argument("--input", help="Path to the input trace file.")
+    input_group.add_argument(
+        "--pipe", action="store_true", help="Read trace filenames from stdin (pipe)."
+    )
     return parser
+
+
+def get_trace_files(args):
+    if args.pipe:
+        if select.select([sys.stdin], [], [], 0.0)[0]:
+            trace_files = [line.strip() for line in sys.stdin if line.strip()]
+        else:
+            print("Error: No filenames received from stdin. Provide input with --pipe or use --input.")
+            sys.exit(1)
+    else:
+        trace_files = [args.input]
+
+    return trace_files
 
 
 def compute_trace_statistics(trace_file):
@@ -41,11 +59,20 @@ def compute_trace_statistics(trace_file):
 def main():
     parser = parse_arguments()
     args = parser.parse_args()
-    if not os.path.exists(args.input):
-        print(f"Error: The file {args.input} does not exist.")
-        sys.exit(1)
+    trace_files = get_trace_files(args)
 
-    compute_trace_statistics(args.input)
+    processed_files = 0
+    for trace_file in trace_files:
+        if not os.path.exists(trace_file):
+            print(f"Error: The file {trace_file} does not exist.")
+            continue
+
+        compute_trace_statistics(trace_file)
+        processed_files += 1
+
+    if processed_files == 0:
+        print("Error: No valid trace files to process.")
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a mutually exclusive --pipe option alongside --input for trace_stats
- read trace filenames from stdin when piping and validate availability before processing
- process multiple trace files sequentially and guard against missing or empty inputs

## Testing
- python -m traceratops.trace_stats --help


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6926eae7c0a883309f4db18389751580)