### PR TITLE
Add pipe input support to trace scripts

### DIFF
--- a/traceratops/trace_correct_coordinates.py
+++ b/traceratops/trace_correct_coordinates.py
@@ -9,6 +9,8 @@ to minimize their deviation from the center of mass (CoM) of their respective tr
 
 import argparse
 import os
+import select
+import sys
 
 import numpy as np
 from astropy.table import Table
@@ -16,8 +18,12 @@ from astropy.table import Table
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--input", required=True, help="Path to the input trace file (ECSV format)."
+    input_group = parser.add_mutually_exclusive_group(required=True)
+    input_group.add_argument(
+        "--input", help="Path to the input trace file (ECSV format)."
+    )
+    input_group.add_argument(
+        "--pipe", action="store_true", help="Read input filenames from stdin (pipe)."
     )
     parser.add_argument(
         "--output",
@@ -36,6 +42,21 @@ def parse_arguments():
         help="Convergence threshold for Z shifts (default: 0.01).",
     )
     return parser
+
+
+def get_trace_files(args):
+    if args.pipe:
+        if select.select([sys.stdin], [], [], 0.0)[0]:
+            trace_files = [line.strip() for line in sys.stdin if line.strip()]
+        else:
+            print(
+                "Error: No filenames received from stdin. Provide input with --pipe or use --input."
+            )
+            sys.exit(1)
+    else:
+        trace_files = [args.input]
+
+    return trace_files
 
 
 def compute_center_of_mass(trace_table):
@@ -125,28 +146,36 @@ def main():
     parser = parse_arguments()
     args = parser.parse_args()
 
-    # Determine output filename
-    if args.output:
-        output_filename = args.output
-    else:
-        base, ext = os.path.splitext(args.input)
-        output_filename = f"{base}_corrected{ext}"
+    trace_files = get_trace_files(args)
+    if args.output and len(trace_files) > 1:
+        print("Error: --output can only be used when processing a single input file.")
+        sys.exit(1)
 
-    # Load the trace table
-    print(f"Loading trace table: {args.input}")
-    trace_table = Table.read(args.input, format="ascii.ecsv")
+    for trace_file in trace_files:
+        # Determine output filename
+        if args.output:
+            output_filename = args.output
+        else:
+            base, ext = os.path.splitext(trace_file)
+            output_filename = f"{base}_corrected{ext}"
 
-    # Apply Z-offset correction
-    print(
-        f"Optimizing Z-offsets with max {args.max_iter} iterations and tolerance {args.tolerance}..."
-    )
-    corrected_trace_table = optimize_z_offsets(
-        trace_table, args.max_iter, args.tolerance
-    )
+        # Load the trace table
+        print(f"Loading trace table: {trace_file}")
+        trace_table = Table.read(trace_file, format="ascii.ecsv")
 
-    # Save the corrected trace table
-    corrected_trace_table.write(output_filename, format="ascii.ecsv", overwrite=True)
-    print(f"Saved corrected trace table: {output_filename}")
+        # Apply Z-offset correction
+        print(
+            f"Optimizing Z-offsets with max {args.max_iter} iterations and tolerance {args.tolerance}..."
+        )
+        corrected_trace_table = optimize_z_offsets(
+            trace_table, args.max_iter, args.tolerance
+        )
+
+        # Save the corrected trace table
+        corrected_trace_table.write(
+            output_filename, format="ascii.ecsv", overwrite=True
+        )
+        print(f"Saved corrected trace table: {output_filename}")
 
 
 if __name__ == "__main__":

--- a/traceratops/trace_export_to_fofct.py
+++ b/traceratops/trace_export_to_fofct.py
@@ -16,6 +16,8 @@ required_keys = ["genome_assembly", "experimenter_name", "experimenter_contact"]
 import csv
 import json
 import os
+import select
+import sys
 from argparse import ArgumentParser
 
 import pandas as pd
@@ -24,7 +26,11 @@ from astropy.io import ascii
 
 def parse_arguments():
     parser = ArgumentParser(description=__doc__)
-    parser.add_argument("--ecsv_file", help="Path to the ECSV file")
+    input_group = parser.add_mutually_exclusive_group(required=True)
+    input_group.add_argument("--ecsv_file", help="Path to the ECSV file")
+    input_group.add_argument(
+        "--pipe", action="store_true", help="Read input filenames from stdin (pipe)."
+    )
     parser.add_argument("--bed_file", help="Path to the BED file")
     parser.add_argument(
         "--json_file",
@@ -36,6 +42,21 @@ def parse_arguments():
         "--output_file", default=None, help="Path to the output CSV file"
     )
     return parser
+
+
+def get_trace_files(args):
+    if args.pipe:
+        if select.select([sys.stdin], [], [], 0.0)[0]:
+            trace_files = [line.strip() for line in sys.stdin if line.strip()]
+        else:
+            print(
+                "Error: No filenames received from stdin. Provide input with --pipe or use --ecsv_file."
+            )
+            sys.exit(1)
+    else:
+        trace_files = [args.ecsv_file]
+
+    return trace_files
 
 
 def load_trace_ecsv_file(ecsv_file):
@@ -228,18 +249,28 @@ if __name__ == "__main__":
     parser = parse_arguments()
     args = parser.parse_args()
 
+    trace_files = get_trace_files(args)
+    if not args.bed_file:
+        print("Error: --bed_file is required.")
+        sys.exit(1)
+
+    if args.output_file and len(trace_files) > 1:
+        print("Error: --output_file can only be used when processing a single input file.")
+        sys.exit(1)
+
     # Load the metadata
     args_json_file = args.json_file or os.path.join(os.getcwd(), "parameters.json")
     metadata = load_json_file(args_json_file)
     check_metadata(metadata)
 
-    output = get_output_file(args.ecsv_file, args.output_file)
+    for ecsv_file in trace_files:
+        output = get_output_file(ecsv_file, args.output_file)
 
-    convert_ecsv_to_csv(
-        args.ecsv_file,
-        output,
-        args.bed_file,
-        metadata["genome_assembly"],
-        metadata["experimenter_name"],
-        metadata["experimenter_contact"],
-    )
+        convert_ecsv_to_csv(
+            ecsv_file,
+            output,
+            args.bed_file,
+            metadata["genome_assembly"],
+            metadata["experimenter_name"],
+            metadata["experimenter_contact"],
+        )

--- a/traceratops/trace_import_from_fofct.py
+++ b/traceratops/trace_import_from_fofct.py
@@ -12,6 +12,8 @@ Required inputs:
 The script will produce an ECSV file that restores the missing columns (`Barcode #`, `Mask_id`, and `label`).
 """
 
+import select
+import sys
 from argparse import ArgumentParser
 
 import pandas as pd
@@ -21,12 +23,31 @@ from astropy.table import Table
 
 def parse_arguments():
     parser = ArgumentParser(description=__doc__)
-    parser.add_argument("--fofct_file", help="Path to the FOFCT file", required=True)
+    input_group = parser.add_mutually_exclusive_group(required=True)
+    input_group.add_argument("--fofct_file", help="Path to the FOFCT file")
+    input_group.add_argument(
+        "--pipe", action="store_true", help="Read input filenames from stdin (pipe)."
+    )
     parser.add_argument("--bed_file", help="Path to the BED file", required=True)
     parser.add_argument(
         "--output_file", default=None, help="Path to the output ECSV file"
     )
     return parser
+
+
+def get_trace_files(args):
+    if args.pipe:
+        if select.select([sys.stdin], [], [], 0.0)[0]:
+            trace_files = [line.strip() for line in sys.stdin if line.strip()]
+        else:
+            print(
+                "Error: No filenames received from stdin. Provide input with --pipe or use --fofct_file."
+            )
+            sys.exit(1)
+    else:
+        trace_files = [args.fofct_file]
+
+    return trace_files
 
 
 def read_column_names_from_csv(csv_file):
@@ -126,28 +147,33 @@ def main():
     parser = parse_arguments()
     args = parser.parse_args()
 
-    # Read column names from the CSV file
-    column_names = read_column_names_from_csv(args.fofct_file)
+    trace_files = get_trace_files(args)
 
-    # Load the files
-    csv_data = load_csv_file(args.fofct_file, column_names)
-    bed_data = load_barcode_bed_file(args.bed_file)
+    if args.output_file and len(trace_files) > 1:
+        print("Error: --output_file can only be used when processing a single input file.")
+        sys.exit(1)
 
-    # Add missing columns
-    csv_data = add_missing_columns(csv_data, bed_data)
+    for fofct_file in trace_files:
+        # Read column names from the CSV file
+        column_names = read_column_names_from_csv(fofct_file)
 
-    # Rename columns to match ECSV format
-    csv_data = rename_columns_for_ecsv(csv_data)
+        # Load the files
+        csv_data = load_csv_file(fofct_file, column_names)
+        bed_data = load_barcode_bed_file(args.bed_file)
 
-    # Define the output ECSV file path
-    output_file = (
-        args.output_file
-        if args.output_file
-        else args.fofct_file.replace(".csv", ".ecsv")
-    )
+        # Add missing columns
+        csv_data = add_missing_columns(csv_data, bed_data)
 
-    # Convert to ECSV format and save
-    convert_csv_to_ecsv(csv_data, output_file)
+        # Rename columns to match ECSV format
+        csv_data = rename_columns_for_ecsv(csv_data)
+
+        # Define the output ECSV file path
+        output_file = (
+            args.output_file if args.output_file else fofct_file.replace(".csv", ".ecsv")
+        )
+
+        # Convert to ECSV format and save
+        convert_csv_to_ecsv(csv_data, output_file)
 
 
 if __name__ == "__main__":

--- a/traceratops/trace_pearsons.py
+++ b/traceratops/trace_pearsons.py
@@ -27,6 +27,15 @@ from traceratops.core.chromatin_trace_table import ChromatinTraceTable
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description=__doc__)
+    input_group = parser.add_mutually_exclusive_group(required=True)
+    input_group.add_argument(
+        "--input",
+        nargs="+",
+        help="Paths to trace files to compare.",
+    )
+    input_group.add_argument(
+        "--pipe", action="store_true", help="Read input filenames from stdin (pipe)."
+    )
     parser.add_argument(
         "-O",
         "--output",
@@ -40,6 +49,21 @@ def parse_arguments():
         "--vmax", type=float, default=10, help="Maximum value for colormap scaling"
     )
     return parser
+
+
+def get_trace_files(args):
+    if args.pipe:
+        if select.select([sys.stdin], [], [], 0.0)[0]:
+            trace_files = [line.strip() for line in sys.stdin if line.strip()]
+        else:
+            print(
+                "Error: No filenames received from stdin. Provide input with --pipe or use --input."
+            )
+            sys.exit(1)
+    else:
+        trace_files = args.input
+
+    return trace_files
 
 
 def find_unique_substrings(filenames):
@@ -303,15 +327,7 @@ def main():
     """
     parser = parse_arguments()
     args = parser.parse_args()
-    trace_files = []
-    if select.select([sys.stdin], [], [], 0.0)[0]:
-        trace_files = [line.rstrip("\n") for line in sys.stdin]
-    else:
-        print(
-            "Nothing in stdin! Please provide list of tracefiles as in:\n$ ls *ecsv | trace_pearsons"
-        )
-    if not trace_files:
-        return
+    trace_files = get_trace_files(args)
 
     print(f"Analyzing {len(trace_files)} trace files...")
 


### PR DESCRIPTION
## Summary
- allow trace_* utilities to accept filenames from stdin via a new --pipe flag
- process multiple inputs safely while guarding single-file-only output options

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6927006e89008330a5e3e9e7ccdccced)