### PR TITLE
Standardize fofct script input flag

### DIFF
--- a/docs/source/scripts/trace/trace_export_to_fofct.md
+++ b/docs/source/scripts/trace/trace_export_to_fofct.md
@@ -48,7 +48,7 @@ We need as run arguments:
 ## Example
 
 ```sh
-trace_export_to_fofct --ecsv_file /path/to/Trace_3D_barcode_KDtree_ROI-5.ecsv --bed_file /path/to/barcode.bed --json_file /path/to/parameters.json --output_file /path/to/output.csv
+trace_export_to_fofct --input /path/to/Trace_3D_barcode_KDtree_ROI-5.ecsv --bed_file /path/to/barcode.bed --json_file /path/to/parameters.json --output_file /path/to/output.csv
 ```
 
 Example json file:

--- a/docs/source/scripts/trace/trace_import_from_fofct.md
+++ b/docs/source/scripts/trace/trace_import_from_fofct.md
@@ -12,7 +12,7 @@
 To convert a CSV file back to the ECSV format using the specified BED and JSON files, you would run:
 
 ```
-trace_import_from_fofct --fofct_file output.csv --bed_file barcode.bed --output_file Trace_3D_barcode_KDtree_ROI-5.ecsv
+trace_import_from_fofct --input output.csv --bed_file barcode.bed --output_file Trace_3D_barcode_KDtree_ROI-5.ecsv
 ```
 
 If the `--output_file` argument is not provided, the script will save the ECSV file with the same name as the input CSV file but with an `.ecsv` extension.

--- a/traceratops/trace_export_to_fofct.py
+++ b/traceratops/trace_export_to_fofct.py
@@ -27,7 +27,7 @@ from astropy.io import ascii
 def parse_arguments():
     parser = ArgumentParser(description=__doc__)
     input_group = parser.add_mutually_exclusive_group(required=True)
-    input_group.add_argument("--ecsv_file", help="Path to the ECSV file")
+    input_group.add_argument("--input", help="Path to the ECSV file")
     input_group.add_argument(
         "--pipe", action="store_true", help="Read input filenames from stdin (pipe)."
     )
@@ -50,11 +50,11 @@ def get_trace_files(args):
             trace_files = [line.strip() for line in sys.stdin if line.strip()]
         else:
             print(
-                "Error: No filenames received from stdin. Provide input with --pipe or use --ecsv_file."
+                "Error: No filenames received from stdin. Provide input with --pipe or use --input."
             )
             sys.exit(1)
     else:
-        trace_files = [args.ecsv_file]
+        trace_files = [args.input]
 
     return trace_files
 

--- a/traceratops/trace_import_from_fofct.py
+++ b/traceratops/trace_import_from_fofct.py
@@ -24,7 +24,7 @@ from astropy.table import Table
 def parse_arguments():
     parser = ArgumentParser(description=__doc__)
     input_group = parser.add_mutually_exclusive_group(required=True)
-    input_group.add_argument("--fofct_file", help="Path to the FOFCT file")
+    input_group.add_argument("--input", help="Path to the FOFCT file")
     input_group.add_argument(
         "--pipe", action="store_true", help="Read input filenames from stdin (pipe)."
     )
@@ -41,11 +41,11 @@ def get_trace_files(args):
             trace_files = [line.strip() for line in sys.stdin if line.strip()]
         else:
             print(
-                "Error: No filenames received from stdin. Provide input with --pipe or use --fofct_file."
+                "Error: No filenames received from stdin. Provide input with --pipe or use --input."
             )
             sys.exit(1)
     else:
-        trace_files = [args.fofct_file]
+        trace_files = [args.input]
 
     return trace_files
 


### PR DESCRIPTION
## Summary
- switch `trace_import_from_fofct` and `trace_export_to_fofct` to use the `--input` flag
- update CLI error messages to match the new flag name
- refresh documentation examples to demonstrate the `--input` option


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692717ee032483308621288bdcb2cd30)