### PR TITLE
Update pipe usage examples

### DIFF
--- a/docs/source/tutorials/using_pipe.md
+++ b/docs/source/tutorials/using_pipe.md
@@ -8,27 +8,27 @@ Use `find` to collect all trace tables in a directory tree, then pipe the list i
 
 ```
 find /data/experiment_42 -name "*.ecsv" \
-  | trace_filter --pipe --n_barcodes 3 --output merged_traces_filtered.ecsv
+  | trace_filter --pipe --n_barcodes 3
 ```
 
-This scans every `.ecsv` file under `/data/experiment_42`, filters them, and writes the combined output to `merged_traces_filtered.ecsv`.
+This scans every `.ecsv` file under `/data/experiment_42` and filters them in a single run.
 
 ## Plot interactions from a saved list
 
 If you already have a text file listing the traces you want to analyze, feed it to plotting commands with `cat` and `--pipe`:
 
 ```
-cat trace_files.txt | plot_4m --pipe --anchor 18 --cutoff 0.20 --output coloc_anchor18.png
+cat trace_files.txt | plot_4m --pipe --anchor 18 --cutoff 0.20
 ```
 
-Here `trace_files.txt` contains one trace path per line. The command produces a 4M interaction plot for anchor barcode `18` with a `0.20` cutoff and saves it as `coloc_anchor18.png`.
+Here `trace_files.txt` contains one trace path per line. The command produces a 4M interaction plot for anchor barcode `18` with a `0.20` cutoff.
 
 ## Analyze traces with other tools
 
 Most traceratops CLI tools that accept trace files support `--pipe`, so you can mix and match pipelines. For example, to run quality analysis across all traces in the current directory:
 
 ```
-ls *.ecsv | trace_analyzer --pipe --output trace_summary.ecsv
+ls *.ecsv | trace_analyzer --pipe
 ```
 
-This reads every listed trace, computes the analysis, and stores the summary in `trace_summary.ecsv`.
+This reads every listed trace and computes the analysis in one pass.


### PR DESCRIPTION
## Summary
- remove --output flag from --pipe usage examples
- adjust accompanying descriptions to match new examples

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6927300342348330bcd4fa4d626cff16)