### PR TITLE
Support .dat input files as ECSV format

### DIFF
--- a/traceratops/core/chromatin_trace_table.py
+++ b/traceratops/core/chromatin_trace_table.py
@@ -123,7 +123,7 @@ class ChromatinTraceTable:
             sys.exit()
 
         file_ext = os.path.splitext(file)[1].lower()
-        if file_ext == ".ecsv":
+        if file_ext in (".ecsv", ".dat"):
             print("$ Importing table from pyHiM format")
             self.data = read_table_from_ecsv(file)
             self.original_format = "ecsv"
@@ -133,7 +133,7 @@ class ChromatinTraceTable:
             self.data = self._convert_4dn_to_astropy(file)
             self.original_format = "4dn"
         else:
-            raise ValueError("Unsupported file format. Use .ecsv or .4dn")
+            raise ValueError("Unsupported file format. Use .ecsv, .dat, or .4dn")
 
         print(f"Successfully loaded trace table: {file}")
         return self.data

--- a/traceratops/core/localization_table.py
+++ b/traceratops/core/localization_table.py
@@ -177,7 +177,7 @@ class LocalizationTable:
             sys.exit()
 
         file_ext = os.path.splitext(file)[1].lower()
-        if file_ext == ".ecsv":
+        if file_ext in (".ecsv", ".dat"):
             print("$ Importing table from pyHiM format")
             barcode_map = read_table_from_ecsv(file)
             self.original_format = "ecsv"
@@ -188,7 +188,7 @@ class LocalizationTable:
             self.data = barcode_map
             self.original_format = "4dn"
         else:
-            raise ValueError("Unsupported file format. Use .ecsv or .4dn")
+            raise ValueError("Unsupported file format. Use .ecsv, .dat, or .4dn")
 
         print(f"$ Successfully loaded barcode localizations file: {file}")
 


### PR DESCRIPTION
## Summary
- allow .dat files to be handled using the existing ECSV reader for localization tables
- extend chromatin trace loading to treat .dat files as ECSV-format inputs
- update error messages to mention .dat support

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69314df4393c8330b04b78015e13bcc2)