### PR TITLE
Document 5-column BED barcode substitution for trace_genomic_coordinates

### DIFF
--- a/docs/source/scripts/trace/trace_genomic_coordinates.md
+++ b/docs/source/scripts/trace/trace_genomic_coordinates.md
@@ -21,6 +21,8 @@ trace_genomic_coordinates --input trace_file.ecsv --bed bed_file.bed --output ou
 **No header!**
 ```
 
+### 4-column BED (default behavior)
+
 ```text
 chrX            14785864        14789298                1
 chrX            14789398        14792430                2
@@ -36,4 +38,24 @@ chrX            14824792        14829604                14
 ```
 
 The last column should contain only numbers and should match the inputs in the Trace table which are themselves taken
-from the filenames processed by pyHiM
+from the filenames processed by pyHiM.
+
+### 5-column BED (barcode substitution)
+
+If you provide a fifth column, trace_genomic_coordinates will substitute barcode names in the Trace table: the 4th
+column must match the barcode ID in the trace table, and the 5th column is the value that will be used after
+substitution.
+
+```text
+chrX            14785864        14789298                1              HoxA1
+chrX            14789398        14792430                2              HoxA2
+chrX            14792433        14795380                3              HoxA3
+chrX            14795381        14798629                7              HoxA7
+chrX            14799003        14802202                8              HoxA8
+chrX            14802255        14805371                9              HoxA9
+chrX            14805412        14809056                10             HoxA10
+chrX            14809057        14812112                11             HoxA11
+chrX            14812113        14814817                12             HoxA12
+chrX            14814823        14818656                13             HoxA13
+chrX            14824792        14829604                14             HoxA14
+```


### PR DESCRIPTION
### Motivation
- Clarify the BED file formats accepted by `trace_genomic_coordinates`, including the default 4-column usage and the undocumented 5-column barcode-substitution behavior.
- Provide concrete examples so users know how to map barcode IDs from the trace table to replacement names.

### Description
- Updated `docs/source/scripts/trace/trace_genomic_coordinates.md` to add a `4-column BED (default behavior)` section and to emphasize that the last column must be numeric and match trace inputs. 
- Added a `5-column BED (barcode substitution)` section that documents that the 4th column must match the barcode ID in the Trace table and the 5th column is the replacement value used by `trace_genomic_coordinates`.
- Included example BED snippets for both 4-column and 5-column cases to illustrate expected formats.

### Testing
- This is a docs-only change and no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696e4dd789648330a86a6e3d7b6c4bae)