### PR TITLE
Add plot_pwd_moments script for PWD moments and Gaussianity matrices

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ trace_3way_coloc = "traceratops.trace_3way_coloc:main"
 plot_compare2matrices = "traceratops.plot_compare2matrices:main"
 collect_files = "traceratops.collect_files:main"
 trace_split_labels = "traceratops.trace_split_labels:main"
+plot_pwd_moments = "traceratops.plot_pwd_moments:main"
 
 [tool.setuptools.packages.find]
 include = ["traceratops*"]

--- a/traceratops/plot_pwd_moments.py
+++ b/traceratops/plot_pwd_moments.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Plot first/second moments and Gaussianity index from trace pairwise relative positions."""
+
+import argparse
+import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from traceratops.core.chromatin_trace_table import ChromatinTraceTable
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, help="Path to input trace file (.ecsv/.dat/.4dn)")
+    parser.add_argument("-O", "--output", default="plots", help="Output folder")
+    parser.add_argument("--plot_format", default="png", choices=["png", "pdf", "svg"], help="Output plot format")
+    parser.add_argument(
+        "--avg_dims",
+        default="none",
+        choices=["none", "xy", "xyz"],
+        help="Average GaussianityIndex over dimensions: none, xy, or xyz",
+    )
+    parser.add_argument(
+        "--coords",
+        default="xyz",
+        choices=["xyz", "zyx"],
+        help="Coordinate order used in trace file. xyz means columns x,y,z. zyx swaps first and last axes.",
+    )
+    return parser
+
+
+def build_conformations(trace_table_data, coord_order="xyz"):
+    barcodes = np.array(sorted({int(b) for b in trace_table_data["Barcode #"]}))
+    traces = np.array(sorted({str(t) for t in trace_table_data["Trace_ID"]}))
+
+    b_to_i = {b: i for i, b in enumerate(barcodes)}
+    t_to_i = {t: i for i, t in enumerate(traces)}
+
+    conf = np.zeros((len(traces), len(barcodes), 3), dtype=float)
+    conf_mask = np.zeros_like(conf, dtype=float)
+
+    x = np.array(trace_table_data["x"], dtype=float)
+    y = np.array(trace_table_data["y"], dtype=float)
+    z = np.array(trace_table_data["z"], dtype=float)
+    if coord_order == "zyx":
+        coords = np.stack([z, y, x], axis=1)
+    else:
+        coords = np.stack([x, y, z], axis=1)
+
+    for row_idx in range(len(trace_table_data)):
+        tid = str(trace_table_data["Trace_ID"][row_idx])
+        bid = int(trace_table_data["Barcode #"][row_idx])
+        ti = t_to_i[tid]
+        bi = b_to_i[bid]
+        conf[ti, bi, :] = coords[row_idx]
+        conf_mask[ti, bi, :] = 1.0
+
+    return conf, conf_mask, barcodes
+
+
+def compute_moments_and_gaussianity(conf, conf_mask):
+    pair_vect = conf[:, :, None, :] - conf[:, None, :, :]
+    pair_mask = conf_mask[:, :, None, :] * conf_mask[:, None, :, :]
+
+    valid = np.sum(pair_mask, axis=0)
+    valid_safe = np.where(valid > 0, valid, np.nan)
+
+    mean_rel = np.sum(pair_vect * pair_mask, axis=0) / valid_safe
+    second_moment = np.sum((pair_vect * pair_mask) ** 2, axis=0) / valid_safe
+    variance = np.maximum(second_moment - mean_rel**2, 0.0)
+
+    fourth_moment = np.sum((pair_vect * pair_mask) ** 4, axis=0) / valid_safe
+    gaussianity = np.divide(
+        3.0 * (second_moment**2),
+        fourth_moment,
+        out=np.full_like(fourth_moment, np.nan),
+        where=fourth_moment > 0,
+    )
+
+    return mean_rel, variance, gaussianity
+
+
+def safe_nanmean_last_axis(arr):
+    valid = np.sum(~np.isnan(arr), axis=-1)
+    summed = np.nansum(arr, axis=-1)
+    return np.divide(summed, valid, out=np.full_like(summed, np.nan, dtype=float), where=valid > 0)
+
+
+def summarize_to_scalar_map(mean_rel, variance, gaussianity, avg_dims):
+    mean_distance = np.linalg.norm(mean_rel, axis=-1)
+    variance_total = np.sum(variance, axis=-1)
+
+    if avg_dims == "xy":
+        gaussianity_map = safe_nanmean_last_axis(gaussianity[:, :, :2])
+    elif avg_dims == "xyz":
+        gaussianity_map = safe_nanmean_last_axis(gaussianity)
+    else:
+        gaussianity_map = gaussianity
+
+    return mean_distance, variance_total, gaussianity_map
+
+
+def _barcode_ticks(barcodes):
+    n = len(barcodes)
+    if n <= 15:
+        idx = np.arange(n)
+    else:
+        idx = np.linspace(0, n - 1, 6, dtype=int)
+    return idx, [str(int(barcodes[i])) for i in idx]
+
+
+def plot_maps(mean_distance, variance, gaussianity, barcodes, out_png):
+    fig, axes = plt.subplots(1, 3, figsize=(18, 6), constrained_layout=True)
+
+    items = [
+        (mean_distance, "Distance matrix", "Mean distance"),
+        (variance, "Variance matrix", "Variance"),
+        (gaussianity, "Gaussianity matrix", "Gaussianity index"),
+    ]
+
+    ticks, labels = _barcode_ticks(barcodes)
+
+    for ax, (mat, title, cbar_label) in zip(axes, items):
+        if mat.ndim == 3:
+            mat = safe_nanmean_last_axis(mat)
+        im = ax.imshow(mat, cmap="coolwarm")
+        ax.set_title(title)
+        ax.set_xlabel("Barcode #")
+        ax.set_ylabel("Barcode #")
+        ax.set_xticks(ticks)
+        ax.set_yticks(ticks)
+        ax.set_xticklabels(labels, rotation=45, ha="right")
+        ax.set_yticklabels(labels)
+        cbar = fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
+        cbar.set_label(cbar_label)
+
+    fig.savefig(out_png, dpi=200)
+    plt.close(fig)
+
+
+def main():
+    args = parse_arguments().parse_args()
+    os.makedirs(args.output, exist_ok=True)
+
+    trace_table = ChromatinTraceTable()
+    trace_table.load(args.input)
+
+    conf, conf_mask, barcodes = build_conformations(trace_table.data, coord_order=args.coords)
+    mean_rel, variance, gaussianity = compute_moments_and_gaussianity(conf, conf_mask)
+    mean_distance, variance_total, gaussianity_map = summarize_to_scalar_map(
+        mean_rel, variance, gaussianity, args.avg_dims
+    )
+
+    stem = os.path.splitext(os.path.basename(args.input))[0]
+    np.save(os.path.join(args.output, f"{stem}_mean_distance.npy"), mean_distance)
+    np.save(os.path.join(args.output, f"{stem}_variance.npy"), variance_total)
+    np.save(os.path.join(args.output, f"{stem}_gaussianity.npy"), gaussianity_map)
+
+    out_plot = os.path.join(args.output, f"{stem}_pwd_moments.{args.plot_format}")
+    plot_maps(mean_distance, variance_total, gaussianity_map, barcodes, out_plot)
+    print(f"Saved: {out_plot}")
+
+
+if __name__ == "__main__":
+    main()

--- a/traceratops/plot_pwd_moments.py
+++ b/traceratops/plot_pwd_moments.py
@@ -46,7 +46,7 @@ def _barcode_ticks(barcodes):
         idx = np.arange(n)
     else:
         idx = np.linspace(0, n - 1, 6, dtype=int)
-    return idx, [str(int(barcodes[i])) for i in idx]
+    return idx, [str(barcodes[i]) for i in idx]
 
 
 def plot_maps(mean_distance, variance, gaussianity, barcodes, out_png):
@@ -182,7 +182,7 @@ def get_mean_distance_map(trace_table, coord_order='xyz'):
 
     print(f"$ Number of bins in map : {sc_matrix.shape}")
 
-    return sc_matrix_mean_distance, sc_matrix_var_distance, sc_matrix_kurtosis
+    return sc_matrix_mean_distance, sc_matrix_var_distance, sc_matrix_kurtosis, barcodes
 
 def main():
     args = parse_arguments().parse_args()
@@ -191,9 +191,10 @@ def main():
     trace_table = ChromatinTraceTable()
     trace_table.load(args.input)
 
-    sc_matrix_mean_distance, sc_matrix_var_distance, sc_matrix_kurtosis = get_mean_distance_map(trace_table, coord_order=args.avg_dims)
+    sc_matrix_mean_distance, sc_matrix_var_distance, sc_matrix_kurtosis, barcodes = get_mean_distance_map(
+        trace_table, coord_order=args.avg_dims
+    )
     gaussianity = 3/sc_matrix_kurtosis
-    barcodes = np.array(sorted({int(b) for b in trace_table.data["Barcode #"]}))
 
     stem = os.path.splitext(os.path.basename(args.input))[0]
     np.save(os.path.join(args.output, f"{stem}_mean_distance.npy"), sc_matrix_mean_distance)

--- a/traceratops/plot_pwd_moments.py
+++ b/traceratops/plot_pwd_moments.py
@@ -1,12 +1,27 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""Plot first/second moments and Gaussianity index from trace pairwise relative positions."""
+"""Plot first/second moments and Gaussianity index from trace pairwise relative positions.
+
+For each pair of barcode, you calculate the distribution of positions of one barcode relatively to the other one (so that gives you a 3D distribution centered on 0).
+Then, from each distribution and along each spatial dimension, you just calculate 3 / kurtosis. 
+
+It equals 1 for a Gaussian and < 1 for a mixture of Gaussian. kurtosis = fourth central moment divided by square variance
+And that's it => You get a matrix for each dimension. You can optionally average them over x and y (and z if it's not too noisy).
+
+
+"""
 
 import argparse
 import os
 
 import matplotlib.pyplot as plt
 import numpy as np
+from sklearn.metrics import pairwise_distances
+from astropy.table import unique
+from tqdm.contrib import tzip
+from scipy.stats import kurtosis
+from scipy.spatial.distance import cdist
+from tqdm.auto import tqdm
 
 from traceratops.core.chromatin_trace_table import ChromatinTraceTable
 
@@ -18,89 +33,12 @@ def parse_arguments():
     parser.add_argument("--plot_format", default="png", choices=["png", "pdf", "svg"], help="Output plot format")
     parser.add_argument(
         "--avg_dims",
-        default="none",
-        choices=["none", "xy", "xyz"],
-        help="Average GaussianityIndex over dimensions: none, xy, or xyz",
-    )
-    parser.add_argument(
-        "--coords",
         default="xyz",
-        choices=["xyz", "zyx"],
-        help="Coordinate order used in trace file. xyz means columns x,y,z. zyx swaps first and last axes.",
+        choices=["xy", "xyz"],
+        help="Average GaussianityIndex over dimensions: xy, or xyz",
     )
+
     return parser
-
-
-def build_conformations(trace_table_data, coord_order="xyz"):
-    barcodes = np.array(sorted({int(b) for b in trace_table_data["Barcode #"]}))
-    traces = np.array(sorted({str(t) for t in trace_table_data["Trace_ID"]}))
-
-    b_to_i = {b: i for i, b in enumerate(barcodes)}
-    t_to_i = {t: i for i, t in enumerate(traces)}
-
-    conf = np.zeros((len(traces), len(barcodes), 3), dtype=float)
-    conf_mask = np.zeros_like(conf, dtype=float)
-
-    x = np.array(trace_table_data["x"], dtype=float)
-    y = np.array(trace_table_data["y"], dtype=float)
-    z = np.array(trace_table_data["z"], dtype=float)
-    if coord_order == "zyx":
-        coords = np.stack([z, y, x], axis=1)
-    else:
-        coords = np.stack([x, y, z], axis=1)
-
-    for row_idx in range(len(trace_table_data)):
-        tid = str(trace_table_data["Trace_ID"][row_idx])
-        bid = int(trace_table_data["Barcode #"][row_idx])
-        ti = t_to_i[tid]
-        bi = b_to_i[bid]
-        conf[ti, bi, :] = coords[row_idx]
-        conf_mask[ti, bi, :] = 1.0
-
-    return conf, conf_mask, barcodes
-
-
-def compute_moments_and_gaussianity(conf, conf_mask):
-    pair_vect = conf[:, :, None, :] - conf[:, None, :, :]
-    pair_mask = conf_mask[:, :, None, :] * conf_mask[:, None, :, :]
-
-    valid = np.sum(pair_mask, axis=0)
-    valid_safe = np.where(valid > 0, valid, np.nan)
-
-    mean_rel = np.sum(pair_vect * pair_mask, axis=0) / valid_safe
-    second_moment = np.sum((pair_vect * pair_mask) ** 2, axis=0) / valid_safe
-    variance = np.maximum(second_moment - mean_rel**2, 0.0)
-
-    fourth_moment = np.sum((pair_vect * pair_mask) ** 4, axis=0) / valid_safe
-    gaussianity = np.divide(
-        3.0 * (second_moment**2),
-        fourth_moment,
-        out=np.full_like(fourth_moment, np.nan),
-        where=fourth_moment > 0,
-    )
-
-    return mean_rel, variance, gaussianity
-
-
-def safe_nanmean_last_axis(arr):
-    valid = np.sum(~np.isnan(arr), axis=-1)
-    summed = np.nansum(arr, axis=-1)
-    return np.divide(summed, valid, out=np.full_like(summed, np.nan, dtype=float), where=valid > 0)
-
-
-def summarize_to_scalar_map(mean_rel, variance, gaussianity, avg_dims):
-    mean_distance = np.linalg.norm(mean_rel, axis=-1)
-    variance_total = np.sum(variance, axis=-1)
-
-    if avg_dims == "xy":
-        gaussianity_map = safe_nanmean_last_axis(gaussianity[:, :, :2])
-    elif avg_dims == "xyz":
-        gaussianity_map = safe_nanmean_last_axis(gaussianity)
-    else:
-        gaussianity_map = gaussianity
-
-    return mean_distance, variance_total, gaussianity_map
-
 
 def _barcode_ticks(barcodes):
     n = len(barcodes)
@@ -122,10 +60,15 @@ def plot_maps(mean_distance, variance, gaussianity, barcodes, out_png):
 
     ticks, labels = _barcode_ticks(barcodes)
 
-    for ax, (mat, title, cbar_label) in zip(axes, items):
+    for i, (ax, (mat, title, cbar_label)) in enumerate(zip(axes, items)):
         if mat.ndim == 3:
             mat = safe_nanmean_last_axis(mat)
-        im = ax.imshow(mat, cmap="coolwarm")
+
+        if i == 2:
+            im = ax.imshow(mat, cmap="RdBu", vmin=0, vmax=1)
+        else:
+            im = ax.imshow(mat, cmap="RdBu")
+
         ax.set_title(title)
         ax.set_xlabel("Barcode #")
         ax.set_ylabel("Barcode #")
@@ -133,12 +76,113 @@ def plot_maps(mean_distance, variance, gaussianity, barcodes, out_png):
         ax.set_yticks(ticks)
         ax.set_xticklabels(labels, rotation=45, ha="right")
         ax.set_yticklabels(labels)
+
         cbar = fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
         cbar.set_label(cbar_label)
+        
 
     fig.savefig(out_png, dpi=200)
     plt.close(fig)
 
+
+
+def build_distance_matrix_fast_min(trace_table, distance_threshold=np.inf, dtype=np.float32, coord_order='xyz'):
+    """
+    Fast version of build_distance_matrix for mode='min' only.
+    """
+
+    data = trace_table.data
+
+    unique_trace_ids = unique(data, keys="Trace_ID")["Trace_ID"].data
+    number_matrices = len(unique_trace_ids)
+
+    unique_barcodes = unique(data, keys="Barcode #")["Barcode #"].data
+    number_unique_barcodes = len(unique_barcodes)
+
+    print(f"$ Found {number_unique_barcodes} barcodes and {number_matrices} traces.", "INFO")
+
+    # Fast barcode -> matrix index mapping
+    barcode_to_index = {bc: i for i, bc in enumerate(unique_barcodes)}
+
+    sc_matrix = np.full(
+        (number_unique_barcodes, number_unique_barcodes, number_matrices),
+        np.nan,
+        dtype=dtype,
+    )
+
+    data_traces = data.group_by("Trace_ID")
+
+    print("> Processing traces...", "INFO")
+
+    for itrace, trace in enumerate(tqdm(data_traces.groups, total=number_matrices)):
+
+        barcodes = np.asarray(trace["Barcode #"].data)
+        barcode_indices = np.array([barcode_to_index[bc] for bc in barcodes])
+
+        if coord_order=='xyz':
+            coords = np.column_stack([
+                np.asarray(trace["x"].data, dtype=dtype),
+                np.asarray(trace["y"].data, dtype=dtype),
+                np.asarray(trace["z"].data, dtype=dtype),
+            ])
+        elif coord_order=='xy':
+            coords = np.column_stack([
+                np.asarray(trace["x"].data, dtype=dtype),
+                np.asarray(trace["y"].data, dtype=dtype),
+                #np.asarray(trace["z"].data, dtype=dtype),
+            ])
+
+        pwd_matrix = cdist(coords, coords)
+
+        # Ignore same barcode pairs
+        valid = barcode_indices[:, None] != barcode_indices[None, :]
+
+        # Apply distance threshold
+        valid &= pwd_matrix < distance_threshold
+
+        if not np.any(valid):
+            continue
+
+        ii, jj = np.where(valid)
+
+        row_idx = barcode_indices[ii]
+        col_idx = barcode_indices[jj]
+        distances = pwd_matrix[ii, jj].astype(dtype)
+
+        # Efficiently assign the minimum distance for duplicate barcode combinations
+        current = sc_matrix[:, :, itrace]
+
+        # np.minimum.at does not handle NaNs as desired, so initialize selected NaNs to inf
+        missing = np.isnan(current[row_idx, col_idx])
+        current[row_idx[missing], col_idx[missing]] = np.inf
+
+        np.minimum.at(current, (row_idx, col_idx), distances)
+
+        # Convert untouched inf values back to NaN
+        current[np.isinf(current)] = np.nan
+
+    return sc_matrix, unique_barcodes
+
+def get_mean_distance_map(trace_table, coord_order='xyz'):
+
+    print(f"$ Number of spots in trace file: {len(trace_table.data)}")
+ 
+    sc_matrix, barcodes = build_distance_matrix_fast_min(trace_table,coord_order=coord_order)
+
+    sc_matrix_mean_distance = np.nanmean(sc_matrix, axis=2)
+
+    sc_matrix_var_distance = np.nanvar(sc_matrix, axis=2)
+
+    sc_matrix_kurtosis = kurtosis(
+        sc_matrix,
+        axis=2,
+        nan_policy='omit',   # ignore NaNs
+        fisher=False          # 0 = Gaussian baseline (recommended)
+    )
+
+    print(f"$ Number of bins in map : {sc_matrix.shape}")
+
+    return sc_matrix_mean_distance, sc_matrix_var_distance, sc_matrix_kurtosis
 
 def main():
     args = parse_arguments().parse_args()
@@ -147,20 +191,20 @@ def main():
     trace_table = ChromatinTraceTable()
     trace_table.load(args.input)
 
-    conf, conf_mask, barcodes = build_conformations(trace_table.data, coord_order=args.coords)
-    mean_rel, variance, gaussianity = compute_moments_and_gaussianity(conf, conf_mask)
-    mean_distance, variance_total, gaussianity_map = summarize_to_scalar_map(
-        mean_rel, variance, gaussianity, args.avg_dims
-    )
+    sc_matrix_mean_distance, sc_matrix_var_distance, sc_matrix_kurtosis = get_mean_distance_map(trace_table, coord_order=args.avg_dims)
+    gaussianity = 3/sc_matrix_kurtosis
+    barcodes = np.array(sorted({int(b) for b in trace_table.data["Barcode #"]}))
 
     stem = os.path.splitext(os.path.basename(args.input))[0]
-    np.save(os.path.join(args.output, f"{stem}_mean_distance.npy"), mean_distance)
-    np.save(os.path.join(args.output, f"{stem}_variance.npy"), variance_total)
-    np.save(os.path.join(args.output, f"{stem}_gaussianity.npy"), gaussianity_map)
+    np.save(os.path.join(args.output, f"{stem}_mean_distance.npy"), sc_matrix_mean_distance)
+    np.save(os.path.join(args.output, f"{stem}_variance.npy"), sc_matrix_var_distance)
+    np.save(os.path.join(args.output, f"{stem}_gaussianity.npy"), gaussianity)
 
     out_plot = os.path.join(args.output, f"{stem}_pwd_moments.{args.plot_format}")
-    plot_maps(mean_distance, variance_total, gaussianity_map, barcodes, out_plot)
+    plot_maps(sc_matrix_mean_distance, sc_matrix_var_distance, gaussianity, barcodes, out_plot)
+
     print(f"Saved: {out_plot}")
+
 
 
 if __name__ == "__main__":

--- a/traceratops/plot_pwd_moments.py
+++ b/traceratops/plot_pwd_moments.py
@@ -69,7 +69,7 @@ def plot_maps(mean_distance, variance, gaussianity, barcodes, out_png):
         else:
             im = ax.imshow(mat, cmap="RdBu")
 
-        ax.set_title(title)
+        ax.set_title(title, fontsize=15)
         ax.set_xlabel("Barcode #")
         ax.set_ylabel("Barcode #")
         ax.set_xticks(ticks)


### PR DESCRIPTION
### Motivation
- Provide a lightweight CLI script to compute pairwise relative-position statistics from chromatin trace files and detect multimodality via a kurtosis-based Gaussianity index (`3/kurtosis`).
- Reuse the existing trace I/O and formats by loading traces with the shared `ChromatinTraceTable` class to stay consistent with other scripts.

### Description
- Add `traceratops/plot_pwd_moments.py` which builds `(traces, barcodes, xyz)` conformation tensors and masks, computes relative position vectors, and derives the first moment (mean distance), the second central moment (variance), and a per-dimension Gaussianity index (`3/kurtosis`).
- Include utility routines `build_conformations`, `compute_moments_and_gaussianity`, `safe_nanmean_last_axis`, `summarize_to_scalar_map`, and `plot_maps` to handle NaN-safe averaging and optional averaging over `xy` or `xyz` dimensions.
- Save computed matrices as `.npy` files and export a 3-panel heatmap figure; add a new console entry point `plot_pwd_moments` in `pyproject.toml`.

### Testing
- Ran the new script on test data with `python traceratops/plot_pwd_moments.py --input test/data/trace_filter/IN/two_traces_seven_spots.ecsv -O /tmp/pwd_moments_test --avg_dims xy`, which completed and saved the `.npy` matrices and figure to the output folder.  (Run completed successfully.)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1001ba98048330b0f80ac9d8efd9af)