### PR TITLE
Fix NumPy 2 NaN compatibility

### DIFF
--- a/traceratops/core/chromatin_trace_table.py
+++ b/traceratops/core/chromatin_trace_table.py
@@ -138,22 +138,22 @@ class ChromatinTraceTable:
         return self.data
 
     def remove_empty_comments(self):
-            try:
-                if len(self.data.meta["comments"]):
-                    self.data.meta["comments"] = [
-                        com for com in self.data.meta["comments"] if com
-                    ]
-            except KeyError:
-                return
-
+        try:
+            if len(self.data.meta["comments"]):
+                self.data.meta["comments"] = [
+                    com for com in self.data.meta["comments"] if com
+                ]
+        except KeyError:
+            return
 
     def remove_duplicate_comments(self):
-            try:
-                if len(self.data.meta["comments"]):
-                    self.data.meta["comments"] = list(dict.fromkeys(self.data.meta["comments"]))
-            except KeyError:
-                return
-
+        try:
+            if len(self.data.meta["comments"]):
+                self.data.meta["comments"] = list(
+                    dict.fromkeys(self.data.meta["comments"])
+                )
+        except KeyError:
+            return
 
     def save(self, file_name, comments=""):
         """

--- a/traceratops/core/him_matrix_operations.py
+++ b/traceratops/core/him_matrix_operations.py
@@ -1086,7 +1086,7 @@ def get_rg_from_pwd(pwd_matrix_0, min_number_pwd=4, threshold=6):
         raise SystemExit("get_rg_from_pwd: Expected square matrix as input.")
 
     # make sure the diagonal is NaN
-    np.fill_diagonal(pwd_matrix, np.NaN)
+    np.fill_diagonal(pwd_matrix, np.nan)
 
     # filters out PWD
     pwd_matrix[pwd_matrix > threshold] = np.nan
@@ -1097,7 +1097,7 @@ def get_rg_from_pwd(pwd_matrix_0, min_number_pwd=4, threshold=6):
     )  # default is to compute the sum of the flattened array
 
     if num_not_nan < min_number_pwd:
-        return np.NaN
+        return np.nan
 
     # calculate Rg
     sqr = np.square(pwd_matrix)
@@ -1126,7 +1126,7 @@ def get_detection_eff_barcodes(sc_matrix_collated):
 
     # make sure the diagonal is NaN
     for i in range(sc_matrix_collated.shape[0]):
-        sc_matrix_collated[i, i, :] = np.NaN
+        sc_matrix_collated[i, i, :] = np.nan
 
     # calculate barcode efficiency
     n_cells = sc_matrix_collated.shape[2]
@@ -1152,7 +1152,7 @@ def get_barcodes_per_cell(sc_matrix_collated):
 
     # make sure the diagonal is NaN
     for i in range(sc_matrix_collated.shape[0]):
-        sc_matrix_collated[i, i, :] = np.NaN
+        sc_matrix_collated[i, i, :] = np.nan
 
     num_barcodes = np.sum(~np.isnan(sc_matrix_collated), axis=0)
     num_barcodes[num_barcodes > 1] = 1

--- a/traceratops/core/him_matrix_operations.py
+++ b/traceratops/core/him_matrix_operations.py
@@ -4,7 +4,6 @@
 contains functions and classes needed for the analysis and plotting of HiM matrices
 """
 
-
 import csv
 import itertools
 import json
@@ -256,10 +255,8 @@ def list_sc_to_keep(p, mask):
         a = [i for i in range(len(mask)) if mask[i] == 0]
         cells_to_plot = a
 
-    print(
-        f'>> label: {p["label"]}\t action:{p["action"]}\
-            \t Ncells2plot:{max(cells_to_plot)}\t Ncells in sc_matrix:{len(mask)}'
-    )
+    print(f'>> label: {p["label"]}\t action:{p["action"]}\
+            \t Ncells2plot:{max(cells_to_plot)}\t Ncells in sc_matrix:{len(mask)}')
 
     return cells_to_plot
 

--- a/traceratops/plot_3way_coloc.py
+++ b/traceratops/plot_3way_coloc.py
@@ -6,6 +6,7 @@ Replot 3-way co-localization matrices from .npy files.
 
 It visualizes the frequency of co-localization between barcodes with reference to an anchor barcode, highlighting the anchor's position with perpendicular lines on the heatmap.
 """
+
 import argparse
 import csv
 import os

--- a/traceratops/plot_4m.py
+++ b/traceratops/plot_4m.py
@@ -15,6 +15,7 @@ a plot showing the frequency of interaction between the anchor barcode and all o
 This is particularly useful for analyzing chromatin organization, DNA-DNA interactions,
 and spatial proximity relationships in microscopy data.
 """
+
 import argparse
 import select
 import sys

--- a/traceratops/plot_bootstrapping.py
+++ b/traceratops/plot_bootstrapping.py
@@ -8,7 +8,6 @@ INPUTS:
 - uniquebarcode list
 """
 
-
 import argparse
 import os
 import sys

--- a/traceratops/plot_compare2matrices.py
+++ b/traceratops/plot_compare2matrices.py
@@ -6,7 +6,6 @@ Plots either the ratio or the difference between two HiM matrices.
 It also plots both matrices together, with one in the upper triangle, and the other in the lower triangle.
 """
 
-
 import argparse
 import os
 import sys

--- a/traceratops/plot_him_matrix.py
+++ b/traceratops/plot_him_matrix.py
@@ -6,7 +6,6 @@ This script calculates and plots matrices (PWD and proximity) from:
     - a file with the unique barcodes used
 """
 
-
 import argparse
 import itertools
 import os

--- a/traceratops/trace_3way_coloc.py
+++ b/traceratops/trace_3way_coloc.py
@@ -16,6 +16,7 @@ pairs of other barcodes.
 This is particularly useful for analyzing higher-order chromatin organization and complex
 spatial relationships in microscopy data.
 """
+
 import argparse
 import itertools
 import os


### PR DESCRIPTION
### Motivation
- Ensure traceratops remains compatible with both NumPy 1.x and NumPy 2.x by removing uses of the deprecated `np.NaN` attribute which was removed in NumPy 2.0.

### Description
- Replace all occurrences of `np.NaN` with the supported `np.nan` in `traceratops/core/him_matrix_operations.py` so diagonal and explicit-NaN assignments use the lowercase constant.

### Testing
- Ran a small smoke script (`python -c 'from traceratops.core.him_matrix_operations import get_rg_from_pwd, get_detection_eff_barcodes, get_barcodes_per_cell; import numpy as np; ...'`) under NumPy 2.x which exercised the changed helpers and completed successfully; and
- Ran the automated test `pytest -q test/test_plot_him_matrix.py` which completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4362fecc4083309ec3fca4afb70254)