### PR TITLE
Fix trace_filter clean spot test discovery

### DIFF
--- a/test/test_trace_filter.py
+++ b/test/test_trace_filter.py
@@ -63,9 +63,7 @@ trace_input_files = [
 forpipe_files = [f for f in INPUT_FILES if f.endswith(".txt") and "forpipe" in f]
 one_trace_files = [f for f in INPUT_FILES if "one_trace_four_spots.ecsv" in f]
 duplicate_spot_files = [
-    f
-    for f in INPUT_FILES
-    if f in {"duplicate_spot.ecsv", "duplicate_spot_id.ecsv"}
+    f for f in INPUT_FILES if f in {"duplicate_spot.ecsv", "duplicate_spot_id.ecsv"}
 ]
 
 

--- a/test/test_trace_filter.py
+++ b/test/test_trace_filter.py
@@ -53,7 +53,7 @@ def _test_trace_filter_common(
 
 # ==== FILE LISTS ====
 
-INPUT_FILES = os.listdir(INPUT_DIR)
+INPUT_FILES = sorted(os.listdir(INPUT_DIR))
 
 trace_input_files = [
     f
@@ -62,7 +62,11 @@ trace_input_files = [
 ]
 forpipe_files = [f for f in INPUT_FILES if f.endswith(".txt") and "forpipe" in f]
 one_trace_files = [f for f in INPUT_FILES if "one_trace_four_spots.ecsv" in f]
-duplicate_spot_files = [f for f in INPUT_FILES if "duplicate_spot" in f]
+duplicate_spot_files = [
+    f
+    for f in INPUT_FILES
+    if f in {"duplicate_spot.ecsv", "duplicate_spot_id.ecsv"}
+]
 
 
 # ==== TESTS ====

--- a/traceratops/core/him_matrix_operations.py
+++ b/traceratops/core/him_matrix_operations.py
@@ -255,8 +255,10 @@ def list_sc_to_keep(p, mask):
         a = [i for i in range(len(mask)) if mask[i] == 0]
         cells_to_plot = a
 
-    print(f'>> label: {p["label"]}\t action:{p["action"]}\
-            \t Ncells2plot:{max(cells_to_plot)}\t Ncells in sc_matrix:{len(mask)}')
+    print(
+        f'>> label: {p["label"]}\t action:{p["action"]}\
+            \t Ncells2plot:{max(cells_to_plot)}\t Ncells in sc_matrix:{len(mask)}'
+    )
 
     return cells_to_plot
 


### PR DESCRIPTION
### Motivation
- The `test_clean_spots` parametrization was nondeterministic and picked up generated PNG/ECSV artifacts from previous runs, which are unsupported inputs for the `trace_filter` CLI and caused failures.

### Description
- Make input discovery deterministic by using `INPUT_FILES = sorted(os.listdir(INPUT_DIR))` in `test/test_trace_filter.py`.
- Restrict `duplicate_spot_files` to the canonical ECSV fixtures (`duplicate_spot.ecsv` and `duplicate_spot_id.ecsv`) so generated PNG/ECSV artifacts are not reused as `--input` to `trace_filter`.
- Keep test helper logic unchanged while preventing stale artifacts from being interpreted as trace inputs.

### Testing
- Ran `pytest test/test_trace_filter.py::test_clean_spots` which passed `2 passed` locally.
- Ran full test suite with `pytest -q` which resulted in `87 passed` and no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4531ec09ac83308e8bde723a2257f7)