### PR TITLE
Document localization_analyzer script in ReadTheDocs

### DIFF
--- a/docs/source/scripts/localization.md
+++ b/docs/source/scripts/localization.md
@@ -2,6 +2,7 @@
 
 - Merge ([localization_merge](localization/localization_merge.md))
 - Collect files ([collect_files](localization/collect_files.md))
+- Analyze localization QC ([localization_analyzer](localization/localization_analyzer.md))
 
 ```{toctree}
 :maxdepth: 1
@@ -9,4 +10,5 @@
 
 localization/localization_merge
 localization/collect_files
+localization/localization_analyzer
 ```

--- a/docs/source/scripts/localization/localization_analyzer.md
+++ b/docs/source/scripts/localization/localization_analyzer.md
@@ -1,0 +1,58 @@
+# localization_analyzer
+
+**Reliability status**: `development`
+
+```{eval-rst}
+.. argparse::
+   :ref: traceratops.localization_analyzer.parse_arguments
+   :prog: localization_analyzer
+```
+
+## What it does
+
+`localization_analyzer` loads one localization table and generates a quality-control
+summary plot for the detected barcode localizations. The plot includes:
+
+- SNR distribution per barcode.
+- SNR versus z-position scatter plot, colored by object class.
+- Number of detections per barcode.
+- Roundness versus skew scatter plot, colored by barcode.
+
+The input table is read with `LocalizationTable.load`, so the script supports the
+same localization formats as the localization table reader, including `.ecsv`,
+`.dat`, and `.4dn` files.
+
+## Usage examples
+
+Create the default PNG output, `localization_distribution_fluxes.png`:
+
+```bash
+localization_analyzer \
+    --localization_file localizations_3D_barcode.ecsv
+```
+
+Choose an explicit output file:
+
+```bash
+localization_analyzer \
+    --localization_file localizations_3D_barcode.ecsv \
+    --output_file qc/localization_qc.png
+```
+
+Save the plot as SVG:
+
+```bash
+localization_analyzer \
+    --localization_file localizations_3D_barcode.ecsv \
+    --output_file qc/localization_qc \
+    --format svg
+```
+
+## Notes
+
+- `--localization_file` is required.
+- `--format` accepts `png` or `svg` and defaults to `png`.
+- When `--output_file` is omitted, the output is named
+  `localization_distribution_fluxes.<format>`.
+- If `--output_file` includes an extension, it is replaced by the selected
+  `--format` value.


### PR DESCRIPTION
### Motivation
- Provide user-facing documentation for the new `localization_analyzer` CLI by adding a Read the Docs page under the localization scripts so users can discover usage and options.

### Description
- Added `docs/source/scripts/localization/localization_analyzer.md` with argparse-driven CLI docs, purpose, usage examples, and notes about output naming and supported formats.
- Updated `docs/source/scripts/localization.md` to include `localization_analyzer` in the scripts list and hidden toctree so the new page is included in the docs build.

### Testing
- Ran `python -m traceratops.localization_analyzer --help` which completed successfully and printed the CLI usage.
- Ran `python -m sphinx -b html docs/source /tmp/traceratops-docs-build` which failed because Sphinx is not installed in the environment.
- Ran `uv run --with sphinx --with sphinx-rtd-theme --with sphinx-argparse --with myst-parser sphinx-build -b html docs/source /tmp/traceratops-docs-build` which failed due to a dependency download error (failed to fetch `pluggy`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4686b0d6dc833080cd9e36fc0825e6)