### PR TITLE
Normalize 4DN identifier columns as strings

### DIFF
--- a/test/test_trace_merge.py
+++ b/test/test_trace_merge.py
@@ -45,3 +45,31 @@ def test_merge_conflict():
         gen_file, expected_file, shallow=False
     ), f"Difference detected between {gen_file} and {expected_file}"
     os.remove(gen_file)
+
+
+def test_merge_4dn_numeric_spot_id_with_ecsv_spot_id(tmp_path):
+    from astropy.table import Table, vstack
+    from traceratops.core.chromatin_trace_table import ChromatinTraceTable
+
+    fofct_file = tmp_path / "numeric_spot_ids.4dn"
+    fofct_file.write_text(
+        "##FOF-CT_version=v0.1\n"
+        "##Table_namespace=4dn_FOF-CT_core\n"
+        "##genome_assembly=GRCm38\n"
+        "##XYZ_unit=nm\n"
+        "##columns=(Spot_ID, Trace_ID, X, Y, Z, Chrom, Chrom_Start, Chrom_End)\n"
+        "1000000,500365,1275.7,1817.9,5362.4,chr13,55945001,55955000\n"
+    )
+
+    trace = ChromatinTraceTable()
+    fofct_table = trace.load(str(fofct_file))
+    ecsv_table = Table(
+        rows=[("existing", "trace-a", 1.0, 2.0, 3.0, "chr13", 1, 2, 0, -1, 1, "None")],
+        names=fofct_table.colnames,
+    )
+
+    merged = vstack([ecsv_table, fofct_table])
+
+    assert str(fofct_table["Spot_ID"][0]) == "1000000"
+    assert str(fofct_table["Trace_ID"][0]) == "500365"
+    assert len(merged) == 2

--- a/traceratops/core/chromatin_trace_table.py
+++ b/traceratops/core/chromatin_trace_table.py
@@ -210,6 +210,13 @@ class ChromatinTraceTable:
         column_names = self.columns  # self._read_column_names_from_4dn(fofct_file)
         csv_data = pd.read_csv(fofct_file, comment="#", header=None, names=column_names)
 
+        # pyHiM ECSV trace tables store identifiers as strings. 4DN tables
+        # commonly encode them as bare numbers, so normalize identifier columns
+        # before converting to Astropy to keep mixed-format merges type-safe.
+        for column in ("Spot_ID", "Trace_ID"):
+            if column in csv_data.columns:
+                csv_data[column] = csv_data[column].astype(str)
+
         # Rename XYZ columns for Astropy compatibility
         csv_data.rename(columns={"X": "x", "Y": "y", "Z": "z"}, inplace=True)
 

--- a/traceratops/core/localization_table.py
+++ b/traceratops/core/localization_table.py
@@ -99,6 +99,12 @@ class LocalizationTable:
         column_names = self.columns
         csv_data = pd.read_csv(fofct_file, comment="#", header=None, names=column_names)
 
+        # pyHiM Astropy localization tables store Spot_ID as a string. 4DN
+        # files can encode Spot_ID as a bare number, so normalize it before
+        # converting to Astropy to keep mixed-format merges type-safe.
+        if "Spot_ID" in csv_data.columns:
+            csv_data["Spot_ID"] = csv_data["Spot_ID"].astype(str)
+
         # Rename columns for Astropy compatibility
         csv_data.rename(
             columns={


### PR DESCRIPTION
### Motivation
- Prevent `astropy.table.vstack` type conflicts when merging pyHiM `.ecsv` tables (which store `Spot_ID`/`Trace_ID` as strings) with 4DN `.4dn` CSVs that may contain bare numeric identifiers.
- Avoid `TableMergeError` due to incompatible column dtypes (e.g. `bytes`/`int`) when Spot IDs are large numeric values.

### Description
- Normalize identifier columns to strings when reading 4DN files by casting `Spot_ID` to `str` in `LocalizationTable._convert_4dn_to_astropy` (`traceratops/core/localization_table.py`).
- Normalize both `Spot_ID` and `Trace_ID` to `str` in `ChromatinTraceTable._convert_4dn_to_astropy` (`traceratops/core/chromatin_trace_table.py`).
- Add a regression test `test_merge_4dn_numeric_spot_id_with_ecsv_spot_id` to `test/test_trace_merge.py` that creates a `.4dn` with a numeric `Spot_ID`, loads it, merges with an ECSV-style table, and verifies the merge succeeds.

### Testing
- Ran `pytest -q test/test_trace_merge.py` and all tests passed (`3 passed`).
- Compiled the modified modules with `python -m compileall traceratops/core/chromatin_trace_table.py traceratops/core/localization_table.py` with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a48de67bb088330b5871ee5029ece03)