### PR TITLE
Fix clean_spots filtering for merged traces and guard empty-table filtering

### DIFF
--- a/test/test_trace_filter.py
+++ b/test/test_trace_filter.py
@@ -219,3 +219,39 @@ def test_intensity():
     ]
 
     _test_trace_filter_common(input_file, args, suffix="_intensity", clean_png=True)
+
+
+def test_clean_spots_preserves_reused_spot_ids_across_traces():
+    from astropy.table import Table
+    from traceratops.core.chromatin_trace_table import ChromatinTraceTable
+
+    trace = ChromatinTraceTable()
+    trace.data = Table(
+        rows=[
+            ("1", "trace-a", 1, 0.0, 0.0, 0.0),
+            ("1", "trace-b", 2, 1.0, 1.0, 1.0),
+            ("2", "trace-b", 3, 2.0, 2.0, 2.0),
+            ("2", "trace-b", 4, 3.0, 3.0, 3.0),
+        ],
+        names=("Spot_ID", "Trace_ID", "Barcode #", "x", "y", "z"),
+    )
+
+    trace.remove_duplicates()
+
+    assert len(trace.data) == 2
+    assert list(trace.data["Trace_ID"]) == ["trace-a", "trace-b"]
+    assert list(trace.data["Spot_ID"]) == ["1", "1"]
+
+
+def test_filter_traces_by_n_handles_empty_trace_table():
+    from astropy.table import Table
+    from traceratops.core.chromatin_trace_table import ChromatinTraceTable
+
+    trace = ChromatinTraceTable()
+    trace.data = Table(
+        names=("Spot_ID", "Trace_ID", "Barcode #"), dtype=(str, str, int)
+    )
+
+    trace.filter_traces_by_n(minimum_number_barcodes=4)
+
+    assert len(trace.data) == 0

--- a/test/test_trace_merge.py
+++ b/test/test_trace_merge.py
@@ -1,6 +1,7 @@
 import filecmp
 import os
 import subprocess
+import uuid
 
 TESTS_DIR = os.path.dirname(os.path.realpath(__file__))
 INPUT_DIR = os.path.join(TESTS_DIR, "data", "trace_merge", "IN")
@@ -70,13 +71,27 @@ def test_merge_4dn_numeric_spot_id_with_ecsv_spot_id(tmp_path):
 
     merged = vstack([ecsv_table, fofct_table])
 
-    assert str(fofct_table["Spot_ID"][0]) == "0000001"
-    assert str(fofct_table["Trace_ID"][0]) == "aaaaaaaa"
+    assert uuid.UUID(str(fofct_table["Spot_ID"][0]))
+    assert uuid.UUID(str(fofct_table["Trace_ID"][0]))
     assert len(merged) == 2
 
 
-def test_4dn_conversion_relabels_ids_to_pyhim_nomenclature(tmp_path):
+def test_4dn_conversion_relabels_ids_to_pyhim_nomenclature(tmp_path, monkeypatch):
     from traceratops.core.chromatin_trace_table import ChromatinTraceTable
+
+    generated_ids = iter(
+        [
+            uuid.UUID("00000000-0000-0000-0000-000000000001"),
+            uuid.UUID("00000000-0000-0000-0000-000000000002"),
+            uuid.UUID("00000000-0000-0000-0000-000000000003"),
+            uuid.UUID("00000000-0000-0000-0000-000000000004"),
+            uuid.UUID("00000000-0000-0000-0000-000000000005"),
+        ]
+    )
+    monkeypatch.setattr(
+        "traceratops.core.chromatin_trace_table.uuid.uuid4",
+        lambda: next(generated_ids),
+    )
 
     fofct_file = tmp_path / "numeric_trace_ids.4dn"
     fofct_file.write_text(
@@ -93,5 +108,13 @@ def test_4dn_conversion_relabels_ids_to_pyhim_nomenclature(tmp_path):
     trace = ChromatinTraceTable()
     fofct_table = trace.load(str(fofct_file))
 
-    assert list(fofct_table["Spot_ID"]) == ["0000001", "0000002", "0000003"]
-    assert list(fofct_table["Trace_ID"]) == ["aaaaaaaa", "aaaaaaaa", "aaaaaaab"]
+    assert list(fofct_table["Spot_ID"]) == [
+        "00000000-0000-0000-0000-000000000001",
+        "00000000-0000-0000-0000-000000000002",
+        "00000000-0000-0000-0000-000000000003",
+    ]
+    assert list(fofct_table["Trace_ID"]) == [
+        "00000000-0000-0000-0000-000000000004",
+        "00000000-0000-0000-0000-000000000004",
+        "00000000-0000-0000-0000-000000000005",
+    ]

--- a/test/test_trace_merge.py
+++ b/test/test_trace_merge.py
@@ -70,6 +70,28 @@ def test_merge_4dn_numeric_spot_id_with_ecsv_spot_id(tmp_path):
 
     merged = vstack([ecsv_table, fofct_table])
 
-    assert str(fofct_table["Spot_ID"][0]) == "1000000"
-    assert str(fofct_table["Trace_ID"][0]) == "500365"
+    assert str(fofct_table["Spot_ID"][0]) == "0000001"
+    assert str(fofct_table["Trace_ID"][0]) == "aaaaaaaa"
     assert len(merged) == 2
+
+
+def test_4dn_conversion_relabels_ids_to_pyhim_nomenclature(tmp_path):
+    from traceratops.core.chromatin_trace_table import ChromatinTraceTable
+
+    fofct_file = tmp_path / "numeric_trace_ids.4dn"
+    fofct_file.write_text(
+        "##FOF-CT_version=v0.1\n"
+        "##Table_namespace=4dn_FOF-CT_core\n"
+        "##genome_assembly=GRCm38\n"
+        "##XYZ_unit=nm\n"
+        "##columns=(Spot_ID, Trace_ID, X, Y, Z, Chrom, Chrom_Start, Chrom_End)\n"
+        "1000000,500365,1275.7,1817.9,5362.4,chr13,55945001,55955000\n"
+        "1000001,500365,1276.7,1818.9,5363.4,chr13,55955001,55965000\n"
+        "1000002,500366,1277.7,1819.9,5364.4,chr13,55965001,55975000\n"
+    )
+
+    trace = ChromatinTraceTable()
+    fofct_table = trace.load(str(fofct_file))
+
+    assert list(fofct_table["Spot_ID"]) == ["0000001", "0000002", "0000003"]
+    assert list(fofct_table["Trace_ID"]) == ["aaaaaaaa", "aaaaaaaa", "aaaaaaab"]

--- a/traceratops/core/chromatin_trace_table.py
+++ b/traceratops/core/chromatin_trace_table.py
@@ -5,6 +5,7 @@ trace table management class
 
 import os
 import sys
+import uuid
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -43,39 +44,22 @@ def save_table_to_ecsv(data, path):
     )
 
 
-def format_pyhim_spot_id(index):
-    """Return a pyHiM-style 7-digit Spot_ID for a zero-based index."""
-    return f"{index + 1:07d}"
-
-
-def format_pyhim_trace_id(index):
-    """Return a deterministic pyHiM-style 8-letter Trace_ID."""
-    alphabet = "abcdefghijklmnopqrstuvwxyz"
-    base = len(alphabet)
-    chars = [alphabet[0]] * 8
-    value = index
-
-    for pos in range(7, -1, -1):
-        chars[pos] = alphabet[value % base]
-        value //= base
-
-    if value:
-        raise ValueError("Trace index exceeds pyHiM Trace_ID namespace")
-
-    return "".join(chars)
+def generate_pyhim_identifier():
+    """Return a pyHiM-style UUID identifier."""
+    return str(uuid.uuid4())
 
 
 def relabel_pyhim_identifiers(csv_data):
-    """Relabel 4DN identifiers to pyHiM Astropy Spot_ID/Trace_ID nomenclature."""
+    """Relabel 4DN identifiers to pyHiM Astropy UUID nomenclature."""
     if "Spot_ID" in csv_data.columns:
         csv_data["Spot_ID"] = [
-            format_pyhim_spot_id(index) for index in range(len(csv_data))
+            generate_pyhim_identifier() for _ in range(len(csv_data))
         ]
 
     if "Trace_ID" in csv_data.columns:
         trace_id_map = {
-            trace_id: format_pyhim_trace_id(index)
-            for index, trace_id in enumerate(pd.unique(csv_data["Trace_ID"]))
+            trace_id: generate_pyhim_identifier()
+            for trace_id in pd.unique(csv_data["Trace_ID"])
         }
         csv_data["Trace_ID"] = csv_data["Trace_ID"].map(trace_id_map)
 
@@ -252,8 +236,8 @@ class ChromatinTraceTable:
         csv_data = pd.read_csv(fofct_file, comment="#", header=None, names=column_names)
 
         # 4DN tables can use numeric IDs that clash with pyHiM tooling after
-        # conversion. Relabel them using pyHiM Astropy ECSV nomenclature
-        # (7-digit Spot_ID, 8-letter Trace_ID) before creating the Astropy table.
+        # conversion. Relabel them using pyHiM UUID nomenclature before
+        # creating the Astropy table.
         csv_data = relabel_pyhim_identifiers(csv_data)
 
         # Rename XYZ columns for Astropy compatibility

--- a/traceratops/core/chromatin_trace_table.py
+++ b/traceratops/core/chromatin_trace_table.py
@@ -43,6 +43,45 @@ def save_table_to_ecsv(data, path):
     )
 
 
+def format_pyhim_spot_id(index):
+    """Return a pyHiM-style 7-digit Spot_ID for a zero-based index."""
+    return f"{index + 1:07d}"
+
+
+def format_pyhim_trace_id(index):
+    """Return a deterministic pyHiM-style 8-letter Trace_ID."""
+    alphabet = "abcdefghijklmnopqrstuvwxyz"
+    base = len(alphabet)
+    chars = [alphabet[0]] * 8
+    value = index
+
+    for pos in range(7, -1, -1):
+        chars[pos] = alphabet[value % base]
+        value //= base
+
+    if value:
+        raise ValueError("Trace index exceeds pyHiM Trace_ID namespace")
+
+    return "".join(chars)
+
+
+def relabel_pyhim_identifiers(csv_data):
+    """Relabel 4DN identifiers to pyHiM Astropy Spot_ID/Trace_ID nomenclature."""
+    if "Spot_ID" in csv_data.columns:
+        csv_data["Spot_ID"] = [
+            format_pyhim_spot_id(index) for index in range(len(csv_data))
+        ]
+
+    if "Trace_ID" in csv_data.columns:
+        trace_id_map = {
+            trace_id: format_pyhim_trace_id(index)
+            for index, trace_id in enumerate(pd.unique(csv_data["Trace_ID"]))
+        }
+        csv_data["Trace_ID"] = csv_data["Trace_ID"].map(trace_id_map)
+
+    return csv_data
+
+
 def random_label_cmap(n_labels=256, seed=42):
     """
     Generates a random colormap similar to stardist (so you don't have to import this library just to do it).
@@ -212,12 +251,10 @@ class ChromatinTraceTable:
         column_names = self.columns  # self._read_column_names_from_4dn(fofct_file)
         csv_data = pd.read_csv(fofct_file, comment="#", header=None, names=column_names)
 
-        # pyHiM ECSV trace tables store identifiers as strings. 4DN tables
-        # commonly encode them as bare numbers, so normalize identifier columns
-        # before converting to Astropy to keep mixed-format merges type-safe.
-        for column in ("Spot_ID", "Trace_ID"):
-            if column in csv_data.columns:
-                csv_data[column] = csv_data[column].astype(str)
+        # 4DN tables can use numeric IDs that clash with pyHiM tooling after
+        # conversion. Relabel them using pyHiM Astropy ECSV nomenclature
+        # (7-digit Spot_ID, 8-letter Trace_ID) before creating the Astropy table.
+        csv_data = relabel_pyhim_identifiers(csv_data)
 
         # Rename XYZ columns for Astropy compatibility
         csv_data.rename(columns={"X": "x", "Y": "y", "Z": "z"}, inplace=True)

--- a/traceratops/core/chromatin_trace_table.py
+++ b/traceratops/core/chromatin_trace_table.py
@@ -132,7 +132,9 @@ class ChromatinTraceTable:
             self.data = self._convert_4dn_to_astropy(file)
             self.original_format = "4dn"
         else:
-            raise ValueError("Unsupported file format. Use .ecsv for pyHiM format, .4dn or .csv for FOF-CT format")
+            raise ValueError(
+                "Unsupported file format. Use .ecsv for pyHiM format, .4dn or .csv for FOF-CT format"
+            )
 
         print(f"Successfully loaded trace table: {file}")
         return self.data
@@ -243,7 +245,9 @@ class ChromatinTraceTable:
                 .reset_index(drop=True)
             )
         except KeyError:
-            raise SystemExit(f"! ERROR\nInput file <{fofct_file}> not in FOF-CT format.")
+            raise SystemExit(
+                f"! ERROR\nInput file <{fofct_file}> not in FOF-CT format."
+            )
 
         unique_barcodes["Barcode #"] = range(1, len(unique_barcodes) + 1)
         barcode_mapping = {
@@ -261,7 +265,7 @@ class ChromatinTraceTable:
 
         # Save BED file with Barcode # mapping
 
-        bed_file = fofct_file.split(".")[0] + '_genomic_coordinates.bed'
+        bed_file = fofct_file.split(".")[0] + "_genomic_coordinates.bed"
         unique_barcodes.to_csv(bed_file, sep="\t", header=False, index=False)
         print(f"Saved BED file: {bed_file}")
 
@@ -777,22 +781,25 @@ class ChromatinTraceTable:
             print(f"$ Number of rows to remove: {len(rows_to_remove)}")
 
             if len(trace_table_new) > 0:
-                trace_table_indexed = trace_table_new.group_by("Trace_ID")
+                number_traces_left = len(trace_table_new.group_by("Trace_ID").groups)
+            else:
+                number_traces_left = 0
 
             print(
-                f"$ After filtering, I see \n spots: {len(trace_table_new)} \n traces: {len(trace_table_indexed.groups)}"
+                f"$ After filtering, I see \n spots: {len(trace_table_new)} \n traces: {number_traces_left}"
             )
 
-            # calculates the statistics for the table before processing
-            collective_barcode_stats_new = self.barcode_statistics(trace_table_new)
+            if len(trace_table_new) > 0:
+                # calculates the statistics for the table after processing
+                collective_barcode_stats_new = self.barcode_statistics(trace_table_new)
 
-            # plots statistics of barcodes and saves in file
-            self.plots_barcode_statistics(
-                collective_barcode_stats_new,
-                file_name=f"{trace_file.split('.')[0]}_filtered",
-                kind="matrix",
-                norm=False,
-            )
+                # plots statistics of barcodes and saves in file
+                self.plots_barcode_statistics(
+                    collective_barcode_stats_new,
+                    file_name=f"{trace_file.split('.')[0]}_filtered",
+                    kind="matrix",
+                    norm=False,
+                )
 
         else:
             print("! Error: you are trying to filter an empty trace table!")
@@ -900,23 +907,22 @@ class ChromatinTraceTable:
         trace_table_new = trace_table.copy()
         print("\n$ Removing duplicated barcodes within traces...")
         if len(trace_table) > 0:
-            # indexes trace file
-            trace_table_indexed = trace_table.group_by("Spot_ID")
-
-            # finds barcodes with the same UID and stores UIDs in list
-            spots_to_remove = [
-                trace["Spot_ID"][0]
+            # Spot_ID values are not guaranteed to be globally unique after
+            # merging trace files. Treat a duplicated UID as duplicated only
+            # within the same trace, otherwise clean_spots can remove every
+            # spot from merged tables whose Spot_ID counters restart at 1.
+            trace_table_indexed = trace_table.group_by(["Trace_ID", "Spot_ID"])
+            duplicated_trace_spot_ids = {
+                (trace["Trace_ID"][0], trace["Spot_ID"][0])
                 for trace in trace_table_indexed.groups
                 if len(trace) > 1
-            ]
+            }
 
-            # finds row of the first offending barcode
-            # this only removes one of the duplicated barcodes --> assumes at most there are two copies
-            rows_to_remove = []
-            for idx, row in enumerate(trace_table):
-                spot_id = row["Spot_ID"]
-                if spot_id in spots_to_remove:
-                    rows_to_remove.append(idx)
+            rows_to_remove = [
+                idx
+                for idx, row in enumerate(trace_table)
+                if (row["Trace_ID"], row["Spot_ID"]) in duplicated_trace_spot_ids
+            ]
 
             # removes from table
             trace_table_new.remove_rows(rows_to_remove)
@@ -1006,6 +1012,10 @@ class ChromatinTraceTable:
         """
 
         trace_table = self.data
+
+        if len(trace_table) == 0:
+            print("! Error: you are trying to filter an empty trace table!")
+            return
 
         # indexes trace file
         trace_table_indexed = trace_table.group_by("Trace_ID")


### PR DESCRIPTION
### Motivation
- Merged trace files can reuse `Spot_ID` counters and the prior `--clean_spots` logic treated duplicated `Spot_ID` globally, which could remove nearly every row and empty the table. 
- Subsequent filtering called `group_by("Trace_ID")` on an empty table, triggering an Astropy `IndexError`.

### Description
- Treat duplicated `Spot_ID` as duplicates only when the `(Trace_ID, Spot_ID)` pair appears more than once, so reused Spot_IDs across different traces are preserved (`traceratops/core/chromatin_trace_table.py`).
- Add guards to avoid running `group_by`/statistics/plotting on an empty table after repeated-barcode cleanup and before minimum-barcode filtering (`traceratops/core/chromatin_trace_table.py`).
- Add two regression tests: one to ensure `remove_duplicates()` preserves reused `Spot_ID`s across different `Trace_ID`s, and one to ensure `filter_traces_by_n()` handles an empty trace table without error (`test/test_trace_filter.py`).
- Run code formatting updates to the touched files via `black`.

### Testing
- Ran targeted tests `pytest -q test/test_trace_filter.py::test_clean_spots test/test_trace_filter.py::test_clean_spots_preserves_reused_spot_ids_across_traces test/test_trace_filter.py::test_filter_traces_by_n_handles_empty_trace_table` which passed.
- Ran full test suite with `pytest -q` after changes and formatting, and all tests passed (`90 passed`).
- Ran `black traceratops/core/chromatin_trace_table.py test/test_trace_filter.py` to format modified files (reformatted 2 files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a48e529980883309a5271c1ebd63e92)