### PR TITLE
Improve barcode statistics plot layout

### DIFF
--- a/traceratops/core/chromatin_trace_table.py
+++ b/traceratops/core/chromatin_trace_table.py
@@ -631,9 +631,16 @@ class ChromatinTraceTable:
         sorted_barcodes = sorted([int(x) for x in collective_barcode_stats.keys()])
         data = [collective_barcode_stats[str(key)] for key in sorted_barcodes]
 
-        fig, (ax1) = plt.subplots(nrows=1, ncols=1, figsize=(15, 15))
-
         label, density = ("frequency", True) if norm else ("counts", False)
+
+        if "violin" in kind:
+            figure_size = (15, 15)
+        else:
+            figure_size = self._barcode_matrix_figure_size(len(sorted_barcodes))
+
+        fig, ax1 = plt.subplots(
+            nrows=1, ncols=1, figsize=figure_size, constrained_layout=True
+        )
         ax1.set_title("Relative barcode frequencies", fontsize=30)
 
         if "violin" in kind:
@@ -645,19 +652,32 @@ class ChromatinTraceTable:
                 matrix[idx, :], _ = np.histogram(
                     barcode_data, bins=bins, density=density
                 )
-            bin_number = list(bins)
-            pos = ax1.imshow(np.transpose(matrix), cmap="Reds")
-            ax1.set_xticks(np.arange(matrix.shape[0]), sorted_barcodes, fontsize=15)
-            ax1.set_yticks(np.arange(0, len(bins)), bin_number, fontsize=15)
-            ax1.set_ylabel("number of barcodes", fontsize=25)
-            ax1.set_xlabel("barcode IDs", fontsize=25)
+            bin_number = list(bins[:-1])
+            pos = ax1.imshow(np.transpose(matrix), cmap="Reds", aspect="auto")
+            ax1.set_xticks(np.arange(matrix.shape[0]), sorted_barcodes)
+            ax1.tick_params(axis="x", labelsize=8)
+            plt.setp(
+                ax1.get_xticklabels(),
+                rotation=45,
+                ha="right",
+                rotation_mode="anchor",
+            )
+            ax1.set_yticks(np.arange(len(bin_number)), bin_number, fontsize=12)
+            ax1.set_ylabel("number of barcodes", fontsize=18)
+            ax1.set_xlabel("barcode IDs", fontsize=18)
             fig.colorbar(
                 pos, ax=ax1, location="bottom", anchor=(0.5, 1), shrink=0.4, label=label
             )
         print(
             f"$ Exporting relative barcode frequencies figure to: {file_name}.{format}"
         )
-        fig.savefig(f"{file_name}.{format}")
+        fig.savefig(f"{file_name}.{format}", bbox_inches="tight")
+
+    @staticmethod
+    def _barcode_matrix_figure_size(number_barcodes):
+        """Return a wide figure size that follows the barcode matrix aspect ratio."""
+        width = min(max(number_barcodes * 0.18, 8), 24)
+        return (width, 4.5)
 
     # TODO Rename this here and in `plots_barcode_statistics`
     def _extracted_from_plots_barcode_statistics_38(self, ax1, data, sorted_barcodes):


### PR DESCRIPTION
### Motivation
- The barcode statistics matrix used a square A4-ish canvas and produced overlapping x-axis labels for long or numerous barcode IDs, making the heatmap hard to read.
- The change aims to preserve a more natural wide aspect ratio for matrix plots and prevent label overlap by reducing size and rotating tick labels.

### Description
- Use a matrix-specific wide figure size for non-violin `kind` by adding `_barcode_matrix_figure_size(number_barcodes)` and selecting `figsize` accordingly instead of the fixed `(15, 15)` square canvas.
- Create the figure with `constrained_layout=True` and save with `bbox_inches="tight"` to reduce excess whitespace around the image.
- Render the barcode matrix with `aspect="auto"`, reduce x-axis tick label size via `ax1.tick_params(axis="x", labelsize=8)`, and rotate labels 45° with right alignment using `plt.setp(...)` to avoid overlaps for long labels.
- Adjust y-axis tick handling and axis label font sizes to better match the new, wider aspect ratio.

### Testing
- Ran `python -m compileall traceratops/core/chromatin_trace_table.py` which succeeded.
- Executed a smoke run calling `ChromatinTraceTable().plots_barcode_statistics(..., kind='matrix')` to generate `/tmp/barcode_stats_test.png` which exported successfully.
- Verified the generated PNG by opening it with PIL to inspect its size, and reformatted the file with `python -m black` which completed.
- Ran the test suite with `pytest -q` and all tests passed (`91 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4a6ec35fbc833083c68a527c0df7ce)