### PR TITLE
Homogenize correlation matrix plot font sizes

### DIFF
--- a/traceratops/trace_pearsons.py
+++ b/traceratops/trace_pearsons.py
@@ -290,6 +290,10 @@ def plot_correlation_matrix(
     # Create labels for the plot
     labels = [os.path.basename(unique_identifiers[f]) for f in files]
 
+    title_fontsize = 16
+    label_fontsize = 12
+    tick_fontsize = 10
+
     # Create the figure and axis
     fig, ax = plt.subplots(figsize=(10, 8))
 
@@ -302,20 +306,21 @@ def plot_correlation_matrix(
 
     # Add colorbar
     cbar = fig.colorbar(im, ax=ax)
-    cbar.set_label("Pearson Correlation", fontsize=12)
+    cbar.set_label("Pearson Correlation", fontsize=label_fontsize)
+    cbar.ax.tick_params(labelsize=tick_fontsize)
 
     # Set tick labels
     ax.set_xticks(range(len(files)))
     ax.set_yticks(range(len(files)))
-    ax.set_xticklabels(labels, rotation=90, fontsize=10)
-    ax.set_yticklabels(labels, fontsize=10)
+    ax.set_xticklabels(labels, rotation=90, fontsize=tick_fontsize)
+    ax.set_yticklabels(labels, fontsize=tick_fontsize)
 
     # Add axis labels
-    ax.set_xlabel("Files", fontsize=14)
-    ax.set_ylabel("Files", fontsize=14)
+    ax.set_xlabel("Files", fontsize=label_fontsize)
+    ax.set_ylabel("Files", fontsize=label_fontsize)
 
     # Add title
-    ax.set_title("Trace Table Similarity Matrix", fontsize=16)
+    ax.set_title("Trace Table Similarity Matrix", fontsize=title_fontsize)
 
     # Adjust layout and save
     plt.tight_layout()


### PR DESCRIPTION
### Motivation
- Fix inconsistent font sizing in the correlation matrix plot where the colorbar tick labels were rendering much larger than the matrix tick labels. 
- Ensure title, axis labels, tick labels, and colorbar labels use a consistent, configurable set of font sizes for clearer and more uniform figures.

### Description
- Added three shared font-size variables (`title_fontsize`, `label_fontsize`, `tick_fontsize`) inside `plot_correlation_matrix` in `traceratops/trace_pearsons.py` to centralize sizing. 
- Set the colorbar label font to `label_fontsize` and applied `cbar.ax.tick_params(labelsize=tick_fontsize)` so colorbar ticks match matrix ticks. 
- Applied `tick_fontsize` to `ax.set_xticklabels` and `ax.set_yticklabels`, and used `label_fontsize`/`title_fontsize` for axis labels and the plot title. 
- Kept all other plotting behavior unchanged and preserved saving of the PNG and NPY outputs.

### Testing
- Ran `python -m py_compile traceratops/trace_pearsons.py` which succeeded. 
- Executed a small runtime exercise calling `plot_correlation_matrix(...)` to generate the PNG and NPY files, and both files were created successfully. 
- Ran `git diff --check` to ensure no whitespace or diff issues, which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4b881642548330af575ed48ac5d766)