### PR TITLE
Standardize image output format arguments

### DIFF
--- a/traceratops/localization_analyzer.py
+++ b/traceratops/localization_analyzer.py
@@ -33,9 +33,11 @@ def parse_arguments():
         ),
     )
     parser.add_argument(
+        "--output_format",
         "-f",
         "--format",
-        choices=["png", "svg"],
+        dest="output_format",
+        choices=["png", "svg", "pdf"],
         default="png",
         help="Output plot format. Default = png.",
     )
@@ -46,7 +48,7 @@ def create_dict_args(args):
     p = {}
     p["localization_file"] = args.localization_file
     p["output_file"] = args.output_file
-    p["format"] = args.format
+    p["format"] = args.output_format
 
     print("Input parameters\n" + "-" * 15)
     for item in p.keys():

--- a/traceratops/plot_3way_coloc.py
+++ b/traceratops/plot_3way_coloc.py
@@ -37,9 +37,10 @@ def parse_arguments():
         "--label_map_file", help="Text file with barcode numbers per row"
     )
     parser.add_argument(
-        "--plot_format",
-        help="Available options: svg, pdf, png",
+        "--output_format",
+        choices=["png", "svg", "pdf"],
         default="png",
+        help="Output image format. Default = png.",
     )
     return parser
 
@@ -204,7 +205,7 @@ def main():
             vmax=args.vmax,
             cmap=args.cmap,
             label_map=label_map,
-            file_format=args.plot_format,
+            file_format=args.output_format,
         )
 
 

--- a/traceratops/plot_4m.py
+++ b/traceratops/plot_4m.py
@@ -55,6 +55,12 @@ def parse_arguments():
         "--output", default="colocalization_plot.png", help="Output file for the plot."
     )
     parser.add_argument(
+        "--output_format",
+        choices=["png", "svg", "pdf"],
+        default="png",
+        help="Output image format. Default = png.",
+    )
+    parser.add_argument(
         "--pipe", help="inputs Trace file list from stdin (pipe)", action="store_true"
     )
     parser.add_argument("--x_min", type=int, default=None, help="xscale minimum")
@@ -166,7 +172,13 @@ def bootstrap_colocalization(
 
 
 def plot_frequencies(
-    mean_frequencies, sem_frequencies, anchor_barcodes, output_file, x_min=0, x_max=0
+    mean_frequencies,
+    sem_frequencies,
+    anchor_barcodes,
+    output_file,
+    x_min=0,
+    x_max=0,
+    output_format="png",
 ):
     """Plots colocalization frequencies for multiple anchors separately."""
     # Make sure anchor_barcodes is a list for consistent processing
@@ -201,7 +213,9 @@ def plot_frequencies(
         _x_max = x_max if x_max is not None else max(barcodes) + 1
         plt.xlim(_x_min, _x_max)
         plt.grid(True)
-        output_filename = f"{output_file.split('.')[0]}_anchor_{anchor}.png"
+        output_filename = (
+            f"{output_file.rsplit('.', 1)[0]}_anchor_{anchor}.{output_format}"
+        )
         plt.savefig(output_filename)
         plt.close()  # Close the figure to avoid memory issues with many anchors
 
@@ -245,6 +259,7 @@ def main():
                 args.output,
                 x_min=args.x_min,
                 x_max=args.x_max,
+                output_format=args.output_format,
             )
 
     else:

--- a/traceratops/plot_bootstrapping.py
+++ b/traceratops/plot_bootstrapping.py
@@ -45,7 +45,10 @@ def parse_arguments():
         "--cMax_std", help="Colormap max scale for std map. Default: automatic"
     )
     parser.add_argument(
-        "--plottingFileExtension", help="By default: png. Other options: svg, pdf, png"
+        "--output_format",
+        choices=["png", "svg", "pdf"],
+        default="png",
+        help="Output image format. Default = png.",
     )
     parser.add_argument(
         "--shuffle",
@@ -112,10 +115,7 @@ def create_dict_args(args):
     else:
         run_parameters["cMin_std"] = -1
 
-    if args.plottingFileExtension:
-        run_parameters["plottingFileExtension"] = "." + args.plottingFileExtension
-    else:
-        run_parameters["plottingFileExtension"] = ".png"
+    run_parameters["plottingFileExtension"] = "." + args.output_format
 
     if args.shuffle:
         run_parameters["shuffle"] = args.shuffle

--- a/traceratops/plot_compare2matrices.py
+++ b/traceratops/plot_compare2matrices.py
@@ -46,7 +46,10 @@ def parse_arguments():
         action="store_true",
     )
     parser.add_argument(
-        "--plottingFileExtension", help="By default: svg. Other options: pdf, png"
+        "--output_format",
+        choices=["png", "svg", "pdf"],
+        default="png",
+        help="Output image format. Default = png.",
     )
     parser.add_argument(
         "--normalize",
@@ -131,10 +134,7 @@ def create_dict_args(args):
         run_parameters["ratio"] = args.ratio
     else:
         run_parameters["ratio"] = False
-    if args.plottingFileExtension:
-        run_parameters["plottingFileExtension"] = "." + args.plottingFileExtension
-    else:
-        run_parameters["plottingFileExtension"] = ".svg"
+    run_parameters["plottingFileExtension"] = "." + args.output_format
     if args.normalize:
         run_parameters["normalize"] = args.normalize
     else:

--- a/traceratops/plot_him_matrix.py
+++ b/traceratops/plot_him_matrix.py
@@ -60,9 +60,10 @@ Outputs:
         "-O", "--output", help="Folder for outputs", default="plots"
     )
     parser_advanced.add_argument(
-        "--plot_format",
-        help="Available options: svg, pdf, png",
+        "--output_format",
+        choices=["png", "svg", "pdf"],
         default="png",
+        help="Output image format. Default = png.",
     )
     parser_advanced.add_argument(
         "--shuffle",
@@ -282,7 +283,7 @@ def main():
             u_barcodes,
             input_filename=args.matrix,
             output_folder=args.output,
-            file_format=args.plot_format,
+            file_format=args.output_format,
             n_cells=n_cells,
             font_size=args.fontsize,
             remove_nan=rm_nan,
@@ -293,7 +294,7 @@ def main():
         u_barcodes,
         input_filename=args.matrix,
         output_folder=args.output,
-        file_format=args.plot_format,
+        file_format=args.output_format,
         mode=args.mode,
         n_cells=n_cells,
         font_size=args.fontsize,

--- a/traceratops/plot_matrix_comparison.py
+++ b/traceratops/plot_matrix_comparison.py
@@ -32,6 +32,12 @@ def parse_arguments():
         "--output", help="Name of output plot. Default: scatter_plot.png"
     )
     parser.add_argument(
+        "--output_format",
+        choices=["png", "svg", "pdf"],
+        default="png",
+        help="Output image format. Default = png.",
+    )
+    parser.add_argument(
         "--mode",
         help="Mode used to calculate the mean distance. Can be either 'median', 'KDE' or 'proximity'. Default: median",
     )
@@ -58,12 +64,9 @@ def create_dict_args(args):
         p["input2"] = args.input2
     else:
         p["input2"] = None
-    if args.output:
-        p["output"] = args.output
-        if len(p["output"].split(".")) < 2:
-            p["output"] = p["output"] + ".png"
-    else:
-        p["output"] = "output.png"
+    output_root = args.output if args.output else "output"
+    output_root = output_root.rsplit(".", 1)[0]
+    p["output"] = f"{output_root}.{args.output_format}"
     if args.mode:
         p["mode"] = args.mode
     else:

--- a/traceratops/trace_3way_coloc.py
+++ b/traceratops/trace_3way_coloc.py
@@ -320,7 +320,7 @@ def plot_threeway_matrix(
 
     np.save(f"{output_filename}.npy", mean_matrix)
 
-    plt.savefig(f"{output_filename}.png", dpi=300)
+    plt.savefig(f"{output_filename}.{output_format}", dpi=300)
     print(f"Saved three-way co-localization heatmap to: {output_filename}")
     plt.close()
 
@@ -365,7 +365,9 @@ def plot_threeway_matrix(
 
     # Adjust layout and save
     plt.tight_layout()
-    sem_output_filename = f"{output_file.split('.')[0]}_anchor_{anchor_barcode}_sem.png"
+    sem_output_filename = (
+        f"{output_file.rsplit('.', 1)[0]}_anchor_{anchor_barcode}_sem.{output_format}"
+    )
     plt.savefig(sem_output_filename, dpi=300)
     print(f"Saved SEM heatmap to: {sem_output_filename}")
     plt.close()
@@ -407,6 +409,12 @@ def parse_arguments():
     )
     parser.add_argument(
         "--output", default="threeway_coloc_plot.png", help="Output file for the plot."
+    )
+    parser.add_argument(
+        "--output_format",
+        choices=["png", "svg", "pdf"],
+        default="png",
+        help="Output image format. Default = png.",
     )
     parser.add_argument(
         "--pipe", help="inputs Trace file list from stdin (pipe)", action="store_true"
@@ -457,7 +465,7 @@ def main():
 
                 # Create the plots
                 trace_file_basename = os.path.basename(trace_file)
-                output_filename = f"{args.output.split('.')[0]}_{trace_file_basename.split('.')[0]}.png"
+                output_filename = f"{args.output.rsplit('.', 1)[0]}_{trace_file_basename.rsplit('.', 1)[0]}"
                 plot_threeway_matrix(
                     pair_means,
                     pair_sems,
@@ -466,6 +474,7 @@ def main():
                     distance_cutoff=args.cutoff,
                     vmin=args.vmin,
                     vmax=args.vmax,
+                    output_format=args.output_format,
                 )
 
     else:

--- a/traceratops/trace_analyzer.py
+++ b/traceratops/trace_analyzer.py
@@ -38,8 +38,8 @@ def parse_arguments():
     parser.add_argument(
         "--output_format",
         default="png",
-        choices=["png", "svg"],
-        help="Output image format (png or svg)",
+        choices=["png", "svg", "pdf"],
+        help="Output image format. Default = png.",
     )
     return parser
 
@@ -49,7 +49,7 @@ def create_dict_args(args):
     p["input"] = args.input
     p["rootFolder"] = args.rootFolder
     p["plotXYZ"] = args.plotXYZ
-    p["format"] = args.format
+    p["format"] = args.output_format
 
     p["trace_files"] = []
     if args.pipe:
@@ -413,7 +413,7 @@ def analyze_trace(trace, trace_file, plotXYZ=False, format="png"):
     plotXYZ : bool, optional
         Flag to control whether XYZ traces should be plotted. Default is False.
     format : str, optional
-        Output file format for figures ('png' or 'svg'). Default is 'png'.
+        Output file format for figures ('png', 'svg', or 'pdf'). Default is 'png'.
 
     Returns
     -------
@@ -471,7 +471,7 @@ def process_traces(p):
         Dictionary containing processing parameters:
         - trace_files: List of trace files to process
         - plotXYZ: Flag to control whether XYZ traces should be plotted
-        - format: Output image format (png or svg)
+        - format: Output image format (png, svg, or pdf)
 
     Returns
     -------

--- a/traceratops/trace_analyzer.py
+++ b/traceratops/trace_analyzer.py
@@ -502,7 +502,7 @@ def process_traces(p):
                 )
 
             print(f"> Analyzing traces for {trace_file}")
-            analyze_trace(trace, trace_file, plotXYZ=p["plotXYZ"], format=p["output_format"])
+            analyze_trace(trace, trace_file, plotXYZ=p["plotXYZ"], format=p["format"])
 
     else:
         print(

--- a/traceratops/trace_assign_mask.py
+++ b/traceratops/trace_assign_mask.py
@@ -30,6 +30,12 @@ def parse_arguments():
     parser.add_argument(
         "--pipe", help="inputs Trace file list from stdin (pipe)", action="store_true"
     )
+    parser.add_argument(
+        "--output_format",
+        choices=["png", "svg", "pdf"],
+        default="png",
+        help="Output image format. Default = png.",
+    )
 
     return parser
 
@@ -52,6 +58,7 @@ def create_dict_args(args):
         p["label"] = args.label
     else:
         p["label"] = "labeled"
+    p["output_format"] = args.output_format
     if args.pipe:
         p["pipe"] = True
         if select.select(
@@ -188,7 +195,9 @@ def plot_mask_assignment(
     print(f"$ Saved mask assignment plot: {output_file}")
 
 
-def process_traces(trace_files=[], mask_file="", label="labeled", pixel_size=0.1):
+def process_traces(
+    trace_files=[], mask_file="", label="labeled", pixel_size=0.1, output_format="png"
+):
     print(
         "\n{} trace files to process= {}".format(
             len(trace_files), "\n".join(map(str, trace_files))
@@ -208,7 +217,7 @@ def process_traces(trace_files=[], mask_file="", label="labeled", pixel_size=0.1
             trace.save(outputfile, comments=label)
             print(f"$ Saved output trace file at: {outputfile}")
 
-            plot_file = f"{base_name}_{label}_mask_plot.png"
+            plot_file = f"{base_name}_{label}_mask_plot.{output_format}"
             plot_mask_assignment(
                 trace,
                 mask_file=mask_file,
@@ -229,6 +238,7 @@ def main():
         mask_file=p["mask_file"],
         label=p["label"],
         pixel_size=p["pixel_size"],
+        output_format=p["output_format"],
     )
     print("=" * 9 + "Finished execution" + "=" * 9)
 

--- a/traceratops/trace_filter.py
+++ b/traceratops/trace_filter.py
@@ -85,6 +85,12 @@ def parse_arguments():
         help="inputs Trace file list from stdin (for batch processing)",
         action="store_true",
     )
+    psr_basic.add_argument(
+        "--output_format",
+        choices=["png", "svg", "pdf"],
+        default="png",
+        help="Output image format. Default = png.",
+    )
 
     psr_opt = parser.add_argument_group("Filtering options")
     psr_opt.add_argument(
@@ -229,6 +235,7 @@ def runtime(
     label_to_remove="",
     localizations_file=None,
     intensity_min=0,
+    output_format="png",
 ):
     if len(trace_files) <= 0:
         print("No trace file found to process!")
@@ -254,7 +261,8 @@ def runtime(
         intensities = [row["peak"] for row in localizations_data]
         output_file = localizations_file.split(".")[0]
         localization_table.plot_intensity_distribution(
-            intensities, output_file=output_file + "_localization_intensities.png"
+            intensities,
+            output_file=f"{output_file}_localization_intensities.{output_format}",
         )
 
     # iterates over traces
@@ -305,7 +313,8 @@ def runtime(
             )
             output_file = trace_file.split(".")[0]
             localization_table.plot_intensity_distribution(
-                intensities_kept, output_file=f"{output_file}_filtered_intensities"
+                intensities_kept,
+                output_file=f"{output_file}_filtered_intensities.{output_format}",
             )
 
         print("\n$ Filtering barcode number")
@@ -340,6 +349,7 @@ def main():
         label_to_remove=args.remove_label,
         localizations_file=args.localization_file,
         intensity_min=args.intensity_min,
+        output_format=args.output_format,
     )
 
     print(f"Processed <{n_traces_processed}> trace file(s)\n")

--- a/traceratops/trace_filter_advanced.py
+++ b/traceratops/trace_filter_advanced.py
@@ -37,6 +37,12 @@ def parse_arguments():
     parser.add_argument(
         "--pipe", help="inputs Trace file list from stdin (pipe)", action="store_true"
     )
+    parser.add_argument(
+        "--output_format",
+        choices=["png", "svg", "pdf"],
+        default="png",
+        help="Output image format. Default = png.",
+    )
     return parser
 
 
@@ -70,6 +76,7 @@ def create_dict_args(args):
     else:
         p["N_barcodes"] = 2
 
+    p["output_format"] = args.output_format
     p["trace_files"] = []
     if args.pipe:
         p["pipe"] = True
@@ -128,12 +135,21 @@ def plot_repeated_barcodes(trace_data):
 
 
 class FilterTraces:
-    def __init__(self, data_folder, data_file, dest_folder, threshold=0, verbose=False):
+    def __init__(
+        self,
+        data_folder,
+        data_file,
+        dest_folder,
+        threshold=0,
+        verbose=False,
+        output_format="png",
+    ):
         self.data_folder: str = data_folder
         self.data_file: str = data_file
         self.dest_folder: str = dest_folder
         self.overlapping_threshold: float = threshold  # in µm
         self.verbose: bool = verbose
+        self.output_format: str = output_format
         self.data = None
         self.p95: float = 0
         self.p99: float = 0
@@ -253,8 +269,10 @@ class FilterTraces:
                 f"Median={med}µm - quantile 95%={self.p95}µm - quantile 99%={self.p99}µm"
             )
             if save:
-                fig_path = os.path.join(self.dest_folder, "pairwise_distance_stat.png")
-                plt.savefig(fig_path, dpi=200, format="png")
+                fig_path = os.path.join(
+                    self.dest_folder, f"pairwise_distance_stat.{self.output_format}"
+                )
+                plt.savefig(fig_path, dpi=200, format=self.output_format)
             else:
                 plt.show()
 
@@ -354,8 +372,10 @@ class FilterTraces:
         ax2.legend()
 
         if save:
-            fig_path = os.path.join(self.dest_folder, f"trace_stat_{tag}.png")
-            plt.savefig(fig_path, dpi=200, format="png")
+            fig_path = os.path.join(
+                self.dest_folder, f"trace_stat_{tag}.{self.output_format}"
+            )
+            plt.savefig(fig_path, dpi=200, format=self.output_format)
         else:
             plt.show()
 
@@ -627,8 +647,10 @@ class FilterTraces:
             plt.ylabel("number of occurrences")
             plt.title("distribution of pwd for the repeated barcodes")
             if save:
-                fig_path = os.path.join(self.dest_folder, "duplicated_bc_pwd_stat.png")
-                plt.savefig(fig_path, dpi=200, format="png")
+                fig_path = os.path.join(
+                    self.dest_folder, f"duplicated_bc_pwd_stat.{self.output_format}"
+                )
+                plt.savefig(fig_path, dpi=200, format=self.output_format)
             else:
                 plt.show()
 
@@ -783,7 +805,11 @@ def main():
         # instantiate the class
         # ---------------------
         _trace = FilterTraces(
-            data_folder, file, dest_folder, threshold=overlapping_threshold
+            data_folder,
+            file,
+            dest_folder,
+            threshold=overlapping_threshold,
+            output_format=p["output_format"],
         )
         n_traces_total = _trace.data.shape[0]
 

--- a/traceratops/trace_pearsons.py
+++ b/traceratops/trace_pearsons.py
@@ -56,6 +56,12 @@ def parse_arguments():
     parser.add_argument(
         "--vmax", type=float, default=10, help="Maximum value for colormap scaling"
     )
+    parser.add_argument(
+        "--output_format",
+        choices=["png", "svg", "pdf"],
+        default="png",
+        help="Output image format. Default = png.",
+    )
     parser.add_argument("--verbose", action="store_true", help="Increase verbosity")
     return parser
 
@@ -327,9 +333,9 @@ def plot_correlation_matrix(
     plt.savefig(output_filename, dpi=300)
     print(f"$ Saved correlation matrix as {output_filename}")
 
-    np.save(output_filename[:-4] + ".npy", matrix)
+    np.save(os.path.splitext(output_filename)[0] + ".npy", matrix)
     print(
-        f"$ Saved correlation matrix data in NPY format: {output_filename[:-4]+'.npy'}"
+        f"$ Saved correlation matrix data in NPY format: {os.path.splitext(output_filename)[0] + '.npy'}"
     )
 
     plt.close()
@@ -367,7 +373,9 @@ def main():
     plot_correlation_matrix(
         files,
         corr_matrix,
-        output_filename=os.path.join(args.output, "trace_correlation_matrix.png"),
+        output_filename=os.path.join(
+            args.output, f"trace_correlation_matrix.{args.output_format}"
+        ),
         vmin=args.vmin,
         vmax=args.vmax,
     )


### PR DESCRIPTION
### Motivation
- Make all scripts that produce image files accept the same output-format argument and offer `png` (default), `svg`, and `pdf` so callers can request the desired image type consistently.
- Remove hard-coded ".png" outputs and unify extension handling so downstream automation and docs can rely on a single flag name.
- Fix `trace_analyzer` to read the correct argparse destination (`output_format`) and add PDF support consistent with other tools.

### Description
- Added a unified `--output_format` argument (choices: `png`, `svg`, `pdf`, default `png`) to image-producing scripts such as `trace_analyzer.py`, `trace_3way_coloc.py`, `plot_3way_coloc.py`, `plot_him_matrix.py`, `plot_bootstrapping.py`, `plot_compare2matrices.py`, `plot_matrix_comparison.py`, `plot_4m.py`, `trace_assign_mask.py`, `trace_filter.py`, `trace_filter_advanced.py`, `trace_pearsons.py`, and `localization_analyzer.py`.
- Replaced occurrences of legacy flags/variables (`--plot_format`, `--plottingFileExtension`, `args.plot_format`, `args.plottingFileExtension`, and hard-coded `.png`) to use `--output_format` / `args.output_format` and to build filenames using the requested extension.
- Threaded the selected output format through helper functions and classes (for example `FilterTraces` in `trace_filter_advanced.py`) so saved plot filenames and `plt.savefig(..., format=...)` calls respect the chosen format.
- Normalized several filename-building sites to use robust splitting (`rsplit`) and `os.path.splitext` to avoid double extensions and to produce output names like `name.<format>`.

### Testing
- Ran `python -m compileall -q traceratops` to ensure modules compile and it succeeded. 
- Ran formatting checks and fixes with `black`; initial `black --check` reported files would be reformatted, `black` was applied and a final `black --check` returned clean results. 
- Verified presence and configuration of the new flag via an AST/text-based verification script (checked `--output_format` and `['png','svg','pdf']` choices) which passed. 
- Performed repository checks including `git diff --check` and a search for removed legacy flags; no remaining conflicts or check errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4b8d4cad448330a4be026484cfa1ad)