### PR TITLE
Add startup banner helper and print banners in CLI scripts

### DIFF
--- a/traceratops/collect_files.py
+++ b/traceratops/collect_files.py
@@ -29,6 +29,7 @@ Matches ``ROI-14.ecsv`` but rejects ``ROI-021.ecsv`` (different length).
 
 from __future__ import annotations
 
+from traceratops.script_banner import print_script_banner
 import argparse
 import shutil
 import sys
@@ -359,6 +360,7 @@ def parse_arguments() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     """Entry point.  Returns 0 on success, 1 on business-logic failure."""
+    print_script_banner(__file__, __doc__)
     args = parse_arguments().parse_args(argv)
 
     if not args.root.is_dir():

--- a/traceratops/localization_analyzer.py
+++ b/traceratops/localization_analyzer.py
@@ -10,6 +10,7 @@ The script produces a figure with:
 - scatterplot of roundness versus skew
 """
 
+from traceratops.script_banner import print_script_banner
 import argparse
 import os
 
@@ -76,6 +77,7 @@ def run(p):
 
 
 def main():
+    print_script_banner(__file__, __doc__)
     parser = parse_arguments()
     args = parser.parse_args()
     p = create_dict_args(args)

--- a/traceratops/localization_merge.py
+++ b/traceratops/localization_merge.py
@@ -10,6 +10,7 @@ and merges them into a single output file. It preserves all data from the origin
 while combining them into one comprehensive table.
 """
 
+from traceratops.script_banner import print_script_banner
 import argparse
 import os
 import select
@@ -107,6 +108,7 @@ def run(p):
 
 
 def main():
+    print_script_banner(__file__, __doc__)
     parser = parse_arguments()
     args = parser.parse_args()
     p = create_dict_args(args)

--- a/traceratops/plot_3way_coloc.py
+++ b/traceratops/plot_3way_coloc.py
@@ -7,6 +7,7 @@ Replot 3-way co-localization matrices from .npy files.
 It visualizes the frequency of co-localization between barcodes with reference to an anchor barcode, highlighting the anchor's position with perpendicular lines on the heatmap.
 """
 
+from traceratops.script_banner import print_script_banner
 import argparse
 import csv
 import os
@@ -159,6 +160,7 @@ def load_label_map(filepath, anchor):
 
 
 def main():
+    print_script_banner(__file__, __doc__)
     parser = parse_arguments()
     args = parser.parse_args()
     matrix_files = list(args.input)

--- a/traceratops/plot_4m.py
+++ b/traceratops/plot_4m.py
@@ -16,6 +16,7 @@ This is particularly useful for analyzing chromatin organization, DNA-DNA intera
 and spatial proximity relationships in microscopy data.
 """
 
+from traceratops.script_banner import print_script_banner
 import argparse
 import select
 import sys
@@ -221,6 +222,7 @@ def plot_frequencies(
 
 
 def main():
+    print_script_banner(__file__, __doc__)
     parser = parse_arguments()
     args = parser.parse_args()
 

--- a/traceratops/plot_bootstrapping.py
+++ b/traceratops/plot_bootstrapping.py
@@ -8,6 +8,7 @@ INPUTS:
 - uniquebarcode list
 """
 
+from traceratops.script_banner import print_script_banner
 import argparse
 import os
 import sys
@@ -200,6 +201,7 @@ def plot_results(
 
 
 def main():
+    print_script_banner(__file__, __doc__)
     print(">>> Producing HiM matrix")
 
     parser = parse_arguments()

--- a/traceratops/plot_compare2matrices.py
+++ b/traceratops/plot_compare2matrices.py
@@ -6,6 +6,7 @@ Plots either the ratio or the difference between two HiM matrices.
 It also plots both matrices together, with one in the upper triangle, and the other in the lower triangle.
 """
 
+from traceratops.script_banner import print_script_banner
 import argparse
 import os
 import sys
@@ -215,6 +216,7 @@ def gets_ensemble_matrix(run_parameters, scPWDMatrix_filename=""):
 
 
 def main():
+    print_script_banner(__file__, __doc__)
     parser = parse_arguments()
     args = parser.parse_args()
     run_parameters = create_dict_args(args)

--- a/traceratops/plot_him_matrix.py
+++ b/traceratops/plot_him_matrix.py
@@ -6,6 +6,7 @@ This script calculates and plots matrices (PWD and proximity) from:
     - a file with the unique barcodes used
 """
 
+from traceratops.script_banner import print_script_banner
 import argparse
 import itertools
 import os
@@ -251,6 +252,7 @@ def apply_triangular_mask(matrix, mode="upper"):
 
 
 def main():
+    print_script_banner(__file__, __doc__)
     parser = parse_arguments()
     args = parser.parse_args()
     check_required_arg(args, parser)

--- a/traceratops/plot_matrix_comparison.py
+++ b/traceratops/plot_matrix_comparison.py
@@ -8,6 +8,7 @@ Compare PWD matrices from two experiments
 - same but single cell [TODO]
 """
 
+from traceratops.script_banner import print_script_banner
 import argparse
 import sys
 
@@ -252,6 +253,7 @@ def main_script(p):
 
 
 def main():
+    print_script_banner(__file__, __doc__)
     # [parsing arguments]
     parser = parse_arguments()
     args = parser.parse_args()

--- a/traceratops/script_banner.py
+++ b/traceratops/script_banner.py
@@ -1,0 +1,55 @@
+"""Helpers for printing a standard startup banner for command-line scripts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_SCRIPT_DESCRIPTIONS = {
+    "collect_files.py": "Collect one file per subdirectory using pattern matching.",
+    "localization_analyzer.py": "Load a localization table and plot localization quality-control distributions.",
+    "localization_merge.py": "Merge multiple localization files into a single consolidated output.",
+    "plot_3way_coloc.py": "Replot 3-way co-localization matrices from .npy files.",
+    "plot_4m.py": "Compute barcode interaction frequencies with bootstrapping.",
+    "plot_bootstrapping.py": "Perform bootstrapping analysis on PWD distance matrices.",
+    "plot_compare2matrices.py": "Compare two proximity matrices.",
+    "plot_him_matrix.py": "Calculate and plot PWD and proximity matrices.",
+    "plot_matrix_comparison.py": "Compare PWD matrices from two experiments.",
+    "trace_3way_coloc.py": "Compute three-way co-localization frequencies with bootstrapping.",
+    "trace_analyzer.py": "Analyze chromatin trace files.",
+    "trace_assign_mask.py": "Assign mask labels to traces using numpy masks.",
+    "trace_filter.py": "Filter chromatin trace files.",
+    "trace_filter_advanced.py": "Apply advanced filtering to chromatin trace files.",
+    "trace_genomic_coordinates.py": "Assign genomic coordinates to a chromatin trace table.",
+    "trace_import_from_fofct.py": "Convert a FOF-CT CSV file to a pyHiM trace table in ECSV format.",
+    "trace_merge.py": "This script will merge trace tables provided as inputs.",
+    "trace_pearsons.py": "Compare chromatin trace tables by computing pairwise distances.",
+    "trace_plot.py": "Plot one or multiple traces in 3D.",
+    "trace_split_labels.py": "Split a trace file into two files based on the presence of a label.",
+    "trace_splitter.py": "Split chromatin traces using K-means clustering when radius of gyration exceeds a threshold.",
+    "trace_stats.py": "Compute basic statistics for chromatin trace files.",
+    "trace_to_matrix.py": "Convert a trace file to a matrix using pyHiM core routines.",
+}
+
+
+def print_script_banner(script_file: str, description: str | None) -> None:
+    """Print a standard banner with the script name and a short description."""
+    script_name = Path(script_file).name
+    summary = _SCRIPT_DESCRIPTIONS.get(script_name, "") or _first_description_line(description)
+
+    print(f"------- Running {script_name} --------")
+    if summary:
+        print(summary)
+    print()
+
+
+def _first_description_line(description: str | None) -> str:
+    """Return the first non-empty line of a script docstring."""
+    if description is None:
+        return ""
+
+    for line in description.splitlines():
+        stripped_line = line.strip()
+        if stripped_line:
+            return stripped_line
+
+    return ""

--- a/traceratops/trace_3way_coloc.py
+++ b/traceratops/trace_3way_coloc.py
@@ -17,6 +17,7 @@ This is particularly useful for analyzing higher-order chromatin organization an
 spatial relationships in microscopy data.
 """
 
+from traceratops.script_banner import print_script_banner
 import argparse
 import itertools
 import os
@@ -436,6 +437,7 @@ def get_trace_files(args):
 
 
 def main():
+    print_script_banner(__file__, __doc__)
     parser = parse_arguments()
     args = parser.parse_args()
     _, trace_files = get_trace_files(args)

--- a/traceratops/trace_analyzer.py
+++ b/traceratops/trace_analyzer.py
@@ -4,6 +4,7 @@
 Analyze chromatin trace files.
 """
 
+from traceratops.script_banner import print_script_banner
 import argparse
 import collections
 import select
@@ -504,6 +505,7 @@ def process_traces(p):
 
 
 def main():
+    print_script_banner(__file__, __doc__)
     """
     Main function to execute the trace analyzer script.
 

--- a/traceratops/trace_assign_mask.py
+++ b/traceratops/trace_assign_mask.py
@@ -4,6 +4,7 @@
 Load a trace file and a number of numpy masks and assign them labels
 """
 
+from traceratops.script_banner import print_script_banner
 import argparse
 import os
 import select
@@ -228,6 +229,7 @@ def process_traces(
 
 
 def main():
+    print_script_banner(__file__, __doc__)
     parser = parse_arguments()
     args = parser.parse_args()
     p = create_dict_args(args)

--- a/traceratops/trace_filter.py
+++ b/traceratops/trace_filter.py
@@ -48,6 +48,7 @@ The script can process single files or multiple files via pipe input.
 **Usage**
 """
 
+from traceratops.script_banner import print_script_banner
 import argparse
 import sys
 
@@ -328,6 +329,7 @@ def runtime(
 
 
 def main():
+    print_script_banner(__file__, __doc__)
     print("=" * 10 + "Started execution" + "=" * 10)
     # [parsing arguments]
     parser = parse_arguments()

--- a/traceratops/trace_filter_advanced.py
+++ b/traceratops/trace_filter_advanced.py
@@ -4,6 +4,7 @@
 Advanced script based on trace_filter.
 """
 
+from traceratops.script_banner import print_script_banner
 import argparse
 import os
 import select
@@ -785,6 +786,7 @@ class FilterTraces:
 
 
 def main():
+    print_script_banner(__file__, __doc__)
     # [parsing arguments]
     parser = parse_arguments()
     args = parser.parse_args()

--- a/traceratops/trace_genomic_coordinates.py
+++ b/traceratops/trace_genomic_coordinates.py
@@ -7,6 +7,7 @@ in the trace table based on the 'Barcode #' column. If the BED file provides a f
 the barcode in the trace table is updated to the new value.
 """
 
+from traceratops.script_banner import print_script_banner
 import argparse
 import select
 import sys
@@ -183,6 +184,7 @@ def impute_genomic_coordinates(trace_file, bed_dict, output_file, p):
 
 
 def main():
+    print_script_banner(__file__, __doc__)
     parser = parse_arguments()
     args = parser.parse_args()
     p = create_dict_args(args)

--- a/traceratops/trace_import_from_fofct.py
+++ b/traceratops/trace_import_from_fofct.py
@@ -12,6 +12,7 @@ Required inputs:
 The script will produce an ECSV file that restores the missing columns (`Barcode #`, `Mask_id`, and `label`).
 """
 
+from traceratops.script_banner import print_script_banner
 import select
 import sys
 from argparse import ArgumentParser
@@ -144,6 +145,7 @@ def convert_csv_to_ecsv(csv_data, output_file):
 
 
 def main():
+    print_script_banner(__file__, __doc__)
     parser = parse_arguments()
     args = parser.parse_args()
 

--- a/traceratops/trace_merge.py
+++ b/traceratops/trace_merge.py
@@ -16,6 +16,7 @@ outputs
 ChromatinTraceTable() object and output .ecsv formatted file with assembled trace tables.
 """
 
+from traceratops.script_banner import print_script_banner
 import argparse
 import contextlib
 import io
@@ -112,6 +113,7 @@ def create_out_folder(folder_path):
 
 
 def main():
+    print_script_banner(__file__, __doc__)
     # [parsing arguments]
     parser = parse_arguments()
     args = parser.parse_args()

--- a/traceratops/trace_pearsons.py
+++ b/traceratops/trace_pearsons.py
@@ -10,6 +10,7 @@ trace datasets, helping to identify patterns and relationships in chromatin orga
 across multiple samples or conditions.
 """
 
+from traceratops.script_banner import print_script_banner
 import argparse
 import itertools
 import os
@@ -342,6 +343,7 @@ def plot_correlation_matrix(
 
 
 def main():
+    print_script_banner(__file__, __doc__)
     """
     Main function that executes the trace comparison workflow.
     """

--- a/traceratops/trace_plot.py
+++ b/traceratops/trace_plot.py
@@ -12,6 +12,7 @@ future:
     - output PDBs for all the traces in a trace file
 """
 
+from traceratops.script_banner import print_script_banner
 import argparse
 import os
 import select
@@ -168,6 +169,7 @@ def runtime(
 
 
 def main():
+    print_script_banner(__file__, __doc__)
 
     # [parsing arguments]
     parser = parse_arguments()

--- a/traceratops/trace_split_labels.py
+++ b/traceratops/trace_split_labels.py
@@ -13,6 +13,7 @@ Example:
         Trace_filtered_not:Pdx1.ecsv
 """
 
+from traceratops.script_banner import print_script_banner
 import argparse
 import sys
 
@@ -108,6 +109,7 @@ def process(trace_files, label):
 
 # === ENTRYPOINT ===
 def main():
+    print_script_banner(__file__, __doc__)
 
     print("=" * 10 + " Started execution " + "=" * 10)
 

--- a/traceratops/trace_splitter.py
+++ b/traceratops/trace_splitter.py
@@ -4,6 +4,7 @@
 Split chromatin traces using K-means clustering when their radius of gyration exceeds a threshold.
 """
 
+from traceratops.script_banner import print_script_banner
 import argparse
 import os
 import select
@@ -141,6 +142,7 @@ def split_large_traces(trace_table, std_threshold, num_clusters):
 
 
 def main():
+    print_script_banner(__file__, __doc__)
     """Main function to handle input, processing, and output."""
     parser = parse_arguments()
     args = parser.parse_args()

--- a/traceratops/trace_stats.py
+++ b/traceratops/trace_stats.py
@@ -6,6 +6,7 @@ This script reads a chromatin trace file and computes basic statistics:
    - Number of unique chromatin traces
 """
 
+from traceratops.script_banner import print_script_banner
 import argparse
 import os
 import select
@@ -59,6 +60,7 @@ def compute_trace_statistics(trace_file):
 
 
 def main():
+    print_script_banner(__file__, __doc__)
     parser = parse_arguments()
     args = parser.parse_args()
     trace_files = get_trace_files(args)

--- a/traceratops/trace_to_matrix.py
+++ b/traceratops/trace_to_matrix.py
@@ -4,6 +4,7 @@
 uses the core routines of pyHiM to convert a trace file to a matrix in a standalone script
 """
 
+from traceratops.script_banner import print_script_banner
 import argparse
 import select
 import sys
@@ -108,6 +109,7 @@ def runtime(trace_files=[], colormaps=dict(), distance_threshold=np.inf, outputF
 
 
 def main():
+    print_script_banner(__file__, __doc__)
     # [parsing arguments]
     parser = parse_arguments()
     args = parser.parse_args()


### PR DESCRIPTION
### Motivation
- Provide a consistent, human-friendly startup banner for all command-line entry-point scripts so the script name and a short description are printed at launch.
- Make it easy to display a one-line summary for scripts that lack a usable docstring at runtime.

### Description
- Added a shared helper `traceratops/script_banner.py` that defines `print_script_banner()` and a `_SCRIPT_DESCRIPTIONS` map of short descriptions for known CLI scripts.
- Updated all CLI scripts to import `from traceratops.script_banner import print_script_banner` and call `print_script_banner(__file__, __doc__)` at the start of `main()` (or the entrypoint) so each script prints a banner like `------- Running trace_merge.py --------` followed by a short description.
- Ensured `from __future__` imports and module docstrings remain correctly ordered when inserting the import, and updated the `trace_merge` description text to the requested wording.

### Testing
- Ran `python -m compileall traceratops` and compilation completed successfully.
- Verified the banner output for an example script with `trace_merge --help | head -4` which printed the expected banner and description.
- Ran the test suite with `pytest -q`; results: `79` tests passed and `14` tests failed, with the failures localized to `test_plot_him_matrix.py` (failures caused by differences in generated `nan`-filename formatting expected by the tests, i.e. missing `%` in the generated `nan` filenames).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4cc4fabf74833085b737527401f583)