### PR TITLE
Maintain legacy localization compatibility

### DIFF
--- a/test/test_localization_table.py
+++ b/test/test_localization_table.py
@@ -1,0 +1,52 @@
+from astropy.table import Table
+
+from traceratops.core.localization_table import LocalizationTable
+
+
+def test_plot_distribution_fluxes_skips_legacy_pyhim_table(tmp_path, capsys):
+    legacy_table = Table(
+        rows=[
+            (
+                "1",
+                1,
+                1,
+                1,
+                1,
+                0.0,
+                0.0,
+                0.0,
+                0.5,
+                0.6,
+                0.7,
+                3,
+                1.0,
+                10.0,
+                20.0,
+                0.1,
+            )
+        ],
+        names=(
+            "Buid",
+            "ROI #",
+            "CellID #",
+            "Barcode #",
+            "id",
+            "zcentroid",
+            "xcentroid",
+            "ycentroid",
+            "sharpness",
+            "roundness1",
+            "roundness2",
+            "npix",
+            "sky",
+            "peak",
+            "flux",
+            "mag",
+        ),
+    )
+    output_path = tmp_path / "legacy_distribution.png"
+
+    LocalizationTable().plot_distribution_fluxes(legacy_table, [str(output_path)])
+
+    assert "Please update pyHiM" in capsys.readouterr().out
+    assert not output_path.exists()

--- a/test/test_trace_filter.py
+++ b/test/test_trace_filter.py
@@ -221,6 +221,33 @@ def test_intensity():
     _test_trace_filter_common(input_file, args, suffix="_intensity", clean_png=True)
 
 
+def test_localization_intensity_column_prefers_mean_intensity():
+    from astropy.table import Table
+    from traceratops.core.chromatin_trace_table import ChromatinTraceTable
+
+    localization_table = Table(
+        rows=[(10.0, 20.0)],
+        names=("mean_intensity", "peak"),
+    )
+
+    assert (
+        ChromatinTraceTable._get_localization_intensity_column(localization_table)
+        == "mean_intensity"
+    )
+
+
+def test_localization_intensity_column_accepts_legacy_peak():
+    from astropy.table import Table
+    from traceratops.core.chromatin_trace_table import ChromatinTraceTable
+
+    localization_table = Table(rows=[(20.0,)], names=("peak",))
+
+    assert (
+        ChromatinTraceTable._get_localization_intensity_column(localization_table)
+        == "peak"
+    )
+
+
 def test_clean_spots_preserves_reused_spot_ids_across_traces():
     from astropy.table import Table
     from traceratops.core.chromatin_trace_table import ChromatinTraceTable

--- a/traceratops/core/localization_table.py
+++ b/traceratops/core/localization_table.py
@@ -301,6 +301,16 @@ class LocalizationTable:
         """
         from matplotlib.colors import BoundaryNorm
 
+        if self._uses_legacy_distribution_flux_columns(barcode_map):
+            print(
+                "WARNING: plot_distribution_fluxes received a legacy pyHiM "
+                "localization table. Please update pyHiM to write the current "
+                "localization table format; this legacy table formatting will "
+                "be deprecated in future releases. Skipping distribution flux "
+                "plotting."
+            )
+            return
+
         # initializes figure and font settings explicitly so plots look the same
         # whether this method is called from pyHiM, notebooks, or the CLI.
         figure_size = (30, 15)
@@ -417,6 +427,29 @@ class LocalizationTable:
         fig.savefig("".join(filename_list), dpi=save_dpi)
 
         plt.close(fig)
+
+    @staticmethod
+    def _uses_legacy_distribution_flux_columns(barcode_map):
+        """Return True when ``barcode_map`` has the legacy pyHiM plot schema."""
+        required_columns = {
+            "Barcode #",
+            "zcentroid",
+            "snr",
+            "skew",
+            "object_class",
+            "roundness",
+        }
+        legacy_columns = {"peak", "sharpness", "roundness1", "roundness2"}
+        current_plot_only_columns = {"object_class", "roundness", "skew", "snr"}
+
+        column_names = set(barcode_map.colnames)
+        missing_required_columns = required_columns - column_names
+
+        return (
+            bool(missing_required_columns)
+            and bool(legacy_columns & column_names)
+            and not current_plot_only_columns <= column_names
+        )
 
     def plot_intensity_distribution(
         self, intensities, output_file="intensity_distribution.png"

--- a/traceratops/trace_filter.py
+++ b/traceratops/trace_filter.py
@@ -259,7 +259,10 @@ def runtime(
     if localizations_file and intensity_min:
 
         # Plot intensity distribution to help user choose a threshold
-        intensities = [row["peak"] for row in localizations_data]
+        intensity_column = ChromatinTraceTable._get_localization_intensity_column(
+            localizations_data
+        )
+        intensities = [row[intensity_column] for row in localizations_data]
         output_file = localizations_file.split(".")[0]
         localization_table.plot_intensity_distribution(
             intensities,


### PR DESCRIPTION
### Motivation
- Prevent runtime errors when third-party (older) pyHiM output is passed to plotting routines by detecting legacy localization-table schemas and avoiding operations that assume the new column layout.
- Preserve behavior of existing CLI tools that inspect localization intensities by selecting the correct intensity column from either `mean_intensity` (preferred) or legacy `peak`.

### Description
- In `LocalizationTable.plot_distribution_fluxes()` add a legacy-schema detector and early-return with a clear deprecation/warning message when an old pyHiM-style table is detected, skipping plotting to avoid missing-column exceptions.
- Add `LocalizationTable._uses_legacy_distribution_flux_columns()` as the detection helper that checks for legacy columns (e.g. `peak`, `sharpness`, `roundness1/2`) versus the new plot columns.
- Update `trace_filter` to obtain the intensity column dynamically via `ChromatinTraceTable._get_localization_intensity_column()` and use that column when building intensity histograms, instead of hard-coding `peak`.
- Add tests: `test/test_localization_table.py` verifies the plotting function skips legacy tables with a warning, and `test/test_trace_filter.py` adds assertions that the intensity-column resolver prefers `mean_intensity` and accepts legacy `peak`.

### Testing
- Compiled modified modules with `python -m compileall traceratops/core/localization_table.py traceratops/trace_filter.py` which completed successfully.
- Ran targeted tests with `pytest test/test_localization_table.py test/test_trace_filter.py` and they passed (23 tests total, all green).
- Ran the full test suite with `pytest`; this produced 79 passed and 14 failures in `test/test_plot_him_matrix.py`, which appear unrelated to these changes and are caused by differences in expected/generated filename patterns for `nan%` vs `nan_...`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4cc95344788330b1748de15a214021)