### PR TITLE
Handle degenerate HiM matrix color limits

### DIFF
--- a/traceratops/core/him_matrix_operations.py
+++ b/traceratops/core/him_matrix_operations.py
@@ -710,6 +710,19 @@ def adjust_colorbar(cbar, pos, c_min, clim):
     - c_min: The minimum value to set on the colorbar.
     - clim: The maximum value to set on the colorbar.
     """
+    # Matrices can legitimately contain only zeros (for example with a
+    # proximity threshold of 0 or lower). In that case ``adjust_cmin_cmax``
+    # keeps the historical output filename component as ``nan-0.00``, but
+    # Matplotlib cannot apply non-finite or equal color limits reliably across
+    # versions. Use finite plotting limits while leaving the saved filename
+    # unchanged.
+    if not np.isfinite(c_min):
+        c_min = 0.0
+    if not np.isfinite(clim):
+        clim = 1.0
+    if clim <= c_min:
+        clim = c_min + 1.0
+
     # Set color limits for the colormap
     pos.set_clim(c_min, clim)
 


### PR DESCRIPTION
### Motivation
- Fix failures when plotting proximity matrices that produce non-finite or equal color limits (e.g. all-zero matrices for thresholds like `0` or negative), so PNG output is still generated while preserving historical filename behavior (e.g. `nan-0.00`).

### Description
- Coerce non-finite `c_min`/`clim` to finite plotting bounds and ensure `clim > c_min` before calling `pos.set_clim(...)` in `adjust_colorbar` in `traceratops/core/him_matrix_operations.py` so Matplotlib can render the colorbar reliably across versions without changing saved filenames.

### Testing
- Ran `pytest test/test_plot_him_matrix.py::test_thresholds --maxfail=1 -q` which passed (`4 passed`).
- Ran `pytest test/test_plot_him_matrix.py -q` which passed (`21 passed`).
- Ran the full suite with `pytest -q` which passed (`96 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4cd4c5cec08330a7c189a919798f52)