### PR TITLE
Fix matrix comparison ensemble handling

### DIFF
--- a/test/test_plot_matrix_comparison.py
+++ b/test/test_plot_matrix_comparison.py
@@ -1,0 +1,29 @@
+import sys
+import types
+
+import numpy as np
+
+sys.modules.setdefault("seaborn", types.SimpleNamespace(set=lambda *args, **kwargs: None))
+
+from traceratops.plot_matrix_comparison import calculates_ensemble_matrices
+
+
+def test_calculates_ensemble_matrices_returns_2d_median_matrix():
+    matrix = np.array(
+        [
+            [[np.nan, np.nan], [1.0, 3.0]],
+            [[1.0, 3.0], [np.nan, np.nan]],
+        ]
+    )
+
+    ensemble_matrices = calculates_ensemble_matrices(
+        [matrix], mode="median", max_distance=np.inf
+    )
+
+    assert len(ensemble_matrices) == 1
+    assert ensemble_matrices[0].shape == (2, 2)
+    np.testing.assert_allclose(
+        ensemble_matrices[0],
+        [[np.nan, 2.0], [2.0, np.nan]],
+        equal_nan=True,
+    )

--- a/traceratops/plot_matrix_comparison.py
+++ b/traceratops/plot_matrix_comparison.py
@@ -209,9 +209,14 @@ def calculates_ensemble_matrices(matrices, mode="median", max_distance=2):
             )
         else:
             cells_to_plot = range(matrix.shape[2])
-            mean_sc_matrix = calculate_ensemble_pwd_matrix(
+            mean_sc_matrix, keep_plotting = calculate_ensemble_pwd_matrix(
                 matrix, 1.0, cells_to_plot, mode=mode
             )
+            if not keep_plotting:
+                raise ValueError(
+                    f"Unable to calculate ensemble matrix for mode '{mode}' "
+                    f"from input matrix with shape {matrix.shape}."
+                )
         mean_sc_matrices.append(mean_sc_matrix)
     return mean_sc_matrices
 


### PR DESCRIPTION
### Motivation
- Calling code expected a 2D ensemble matrix but `calculate_ensemble_pwd_matrix` returns `(matrix, keep_plotting)`, which caused an `AttributeError: 'tuple' object has no attribute 'shape'` when vectorizing results; the change prevents that failure and surfaces a clear error when plotting can't continue.

### Description
- Unpack the tuple returned by `calculate_ensemble_pwd_matrix` in `calculates_ensemble_matrices` so `mean_sc_matrix` is a 2D array and `keep_plotting` is handled separately (`traceratops/plot_matrix_comparison.py`).
- Raise a clear `ValueError` when `keep_plotting` is `False`, with a message including the `mode` and the input `matrix.shape` to aid debugging.
- Add a regression test `test/test_plot_matrix_comparison.py` that stubs out `seaborn` and asserts that `calculates_ensemble_matrices([...], mode='median')` returns a single 2D median matrix with expected values.

### Testing
- Ran `pytest test/test_plot_matrix_comparison.py`, which passed (`1 passed, 1 warning`).
- Ran the full test suite with `pytest`, which completed successfully (`97 passed, 1 warning`); the warning is a benign `All-NaN slice encountered` from `np.nanmedian` during the test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4cd5a44f90833089f6d227f046bed6)