### PR TITLE
Update README overview and project metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,88 @@
 # traceratops
 
-*A toolbox for trace analysis, visualization and quality assessment. Corresponding to the post-processing of pyHiM data, compatible with the [4DN FISH Omics Format](https://fish-omics-format.readthedocs.io/en/latest/).*
+*A toolbox for trace analysis, visualization, and quality assessment for chromatin-trace data.*
 
-[**Documentation available online**](https://traceratops.readthedocs.io/en/latest/)
+traceratops provides the post-processing layer for [pyHiM](https://github.com/pyHi-M/pyHiM) multiplexed DNA-FISH workflows. It focuses on the trace and localization tables produced after image processing, and helps users clean, merge, inspect, transform, and visualize those data in formats compatible with the [4DN FISH Omics Format](https://fish-omics-format.readthedocs.io/en/latest/).
 
-## Tutorials
+## Documentation
 
-**Quick Start:** `jupyter notebook docs/source/tutorials/tutorial_01_merge_multi_roi.ipynb`
+The full documentation is available on Read the Docs:
 
-See also [Getting Started with Tutorials](docs/source/tutorials/start_with_ipynb.md).
+- [traceratops documentation](https://traceratops.readthedocs.io/en/latest/)
+- [Installation guide](https://traceratops.readthedocs.io/en/latest/quickstart/installation.html)
+- [Tutorial notebooks](https://traceratops.readthedocs.io/en/latest/tutorials/start_with_ipynb.html)
+
+## What traceratops does
+
+traceratops is organized as a set of command-line tools and Python modules for working with pyHiM post-processing outputs:
+
+- **Trace processing**: merge traces from multiple regions of interest, filter traces and localizations, split traces by labels or criteria, assign masks, add genomic coordinates, and compute descriptive statistics.
+- **Format conversion**: import and export trace tables using the 4DN FISH Omics Format for Chromatin Tracing (FOF-CT).
+- **Matrix generation and analysis**: convert traces into pairwise-distance or proximity matrices, compare matrices, and support downstream chromatin-structure analyses.
+- **Visualization**: plot Hi-M matrices, matrix comparisons, bootstrapping results, multi-way co-localization, and other trace-derived summaries.
+- **Localization quality control**: collect, merge, and analyze localization tables before or alongside trace-level analysis.
+
+The package is intended for users who already have pyHiM-style localization or trace tables and want a documented, scriptable post-processing workflow.
+
+## Installation
+
+traceratops supports Linux, macOS, and Windows. We recommend installing it in a dedicated conda environment:
+
+```bash
+conda create -n traceratops python=3.11
+conda activate traceratops
+```
+
+Clone the repository and install the package:
+
+```bash
+git clone https://github.com/pyHi-M/traceratops.git
+cd traceratops
+pip install -e .
+```
+
+For development and documentation work, install the optional development dependencies:
+
+```bash
+pip install -e '.[dev]'
+```
+
+After installation, traceratops command-line tools such as `trace_filter`, `trace_merge`, `trace_to_matrix`, `trace_stats`, `plot_him_matrix`, and `localization_analyzer` should be available in the active environment.
+
+## Quick start
+
+A practical way to start is to run the first tutorial notebook:
+
+```bash
+jupyter notebook docs/source/tutorials/tutorial_01_merge_multi_roi.ipynb
+```
+
+Additional tutorials cover quality control, threshold filtering, duplicate removal, trace splitting, mask assignment, matrix visualization, multi-way co-localization, dataset comparison, and use of the `--pipe` argument.
+
+## Major dependencies
+
+traceratops is written in Python and relies on the scientific Python ecosystem. Major runtime dependencies include:
+
+- [NumPy](https://numpy.org/) for numerical arrays and matrix operations.
+- [pandas](https://pandas.pydata.org/) for tabular trace and localization data.
+- [Astropy](https://www.astropy.org/) for table I/O, including ECSV workflows.
+- [SciPy](https://scipy.org/) and [scikit-learn](https://scikit-learn.org/) for scientific computing and analysis utilities.
+- [Matplotlib](https://matplotlib.org/) and [Seaborn](https://seaborn.pydata.org/) for plotting and visualization.
+- [tqdm](https://tqdm.github.io/) for progress reporting.
+
+Development and documentation extras include [pytest](https://docs.pytest.org/), [pre-commit](https://pre-commit.com/), [mypy](https://mypy-lang.org/), [Sphinx](https://www.sphinx-doc.org/), [sphinx-rtd-theme](https://sphinx-rtd-theme.readthedocs.io/), [sphinx-argparse](https://sphinx-argparse.readthedocs.io/), [MyST Parser](https://myst-parser.readthedocs.io/), and [sphinx-panels](https://sphinx-panels.readthedocs.io/).
+
+## License
+
+traceratops is distributed under the [GNU General Public License v3.0](LICENSE). The GPLv3 is a copyleft free-software license: you may use, study, share, and modify the software, but redistributed copies or derivative works must preserve the same license terms and provide the corresponding source code as required by the license.
+
+The third-party packages used by traceratops are distributed under their own licenses. Please consult each dependency's project page or package metadata for the exact license terms that apply to those dependencies.
+
+## Authors
+
+traceratops is authored by:
+
+- Marcelo Nollmann — `marcelo.nollmann@cbs.cnrs.fr`
+- Xavier Devos — `xavier.devos@cbs.cnrs.fr`
+
+The project is part of the pyHi-M software ecosystem developed around pyHiM analysis and post-processing workflows.


### PR DESCRIPTION
### Motivation

- Provide a clearer, pyHiM-aligned overview of what traceratops does and who it targets.  
- Surface links to the Read the Docs site, installation steps, major runtime/development dependencies, license, and author credits so new users can get started quickly.

### Description

- Rewrote the README top-level summary to describe traceratops as a post-processing toolbox for pyHiM chromatin-trace data and its compatibility with the 4DN FISH Omics Format.  
- Added a `Documentation` section with links to the Read the Docs site, installation guide, and tutorial index.  
- Added a `What traceratops does` feature list covering trace processing, format conversion (FOF-CT), matrix generation/analysis, visualization, and localization QC.  
- Added an `Installation` quick-start with recommended `conda` environment creation and `pip install -e .` instructions, a `Quick start` notebook entry, a `Major dependencies` list (runtime and dev/docs extras), a `License` explanation referencing `LICENSE`, and an `Authors` section with contact emails.

### Testing

- Ran `git diff --check` on the modified README and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4d181ee08c833081c9b97164845ce5)