### PR TITLE
Convert FOF-CT trace coordinates to micrometers

### DIFF
--- a/test/test_trace_merge.py
+++ b/test/test_trace_merge.py
@@ -3,6 +3,8 @@ import os
 import subprocess
 import uuid
 
+import pytest
+
 TESTS_DIR = os.path.dirname(os.path.realpath(__file__))
 INPUT_DIR = os.path.join(TESTS_DIR, "data", "trace_merge", "IN")
 OUTPUT_DIR = os.path.join(TESTS_DIR, "data", "trace_merge", "OUT")
@@ -73,6 +75,9 @@ def test_merge_4dn_numeric_spot_id_with_ecsv_spot_id(tmp_path):
 
     assert uuid.UUID(str(fofct_table["Spot_ID"][0]))
     assert uuid.UUID(str(fofct_table["Trace_ID"][0]))
+    assert fofct_table["x"][0] == pytest.approx(1.2757)
+    assert fofct_table["y"][0] == pytest.approx(1.8179)
+    assert fofct_table["z"][0] == pytest.approx(5.3624)
     assert len(merged) == 2
 
 
@@ -118,3 +123,25 @@ def test_4dn_conversion_relabels_ids_to_pyhim_nomenclature(tmp_path, monkeypatch
         "00000000-0000-0000-0000-000000000004",
         "00000000-0000-0000-0000-000000000005",
     ]
+
+
+def test_4dn_conversion_keeps_micron_coordinates(tmp_path):
+    from traceratops.core.chromatin_trace_table import ChromatinTraceTable
+
+    fofct_file = tmp_path / "micron_coordinates.4dn"
+    fofct_file.write_text(
+        "##FOF-CT_version=v0.1\n"
+        "##Table_namespace=4dn_FOF-CT_core\n"
+        "##genome_assembly=GRCm38\n"
+        "##XYZ_unit=micron\n"
+        "##columns=(Spot_ID, Trace_ID, X, Y, Z, Chrom, Chrom_Start, Chrom_End)\n"
+        "1,100001,1.7361530513467,1.5554513693079502,6.9461968567717295,chr13,55635001,55645000\n"
+    )
+
+    trace = ChromatinTraceTable()
+    fofct_table = trace.load(str(fofct_file))
+
+    assert fofct_table["x"][0] == pytest.approx(1.7361530513467)
+    assert fofct_table["y"][0] == pytest.approx(1.5554513693079502)
+    assert fofct_table["z"][0] == pytest.approx(6.9461968567717295)
+    assert trace.xyz_unit == "micron"

--- a/traceratops/core/chromatin_trace_table.py
+++ b/traceratops/core/chromatin_trace_table.py
@@ -66,6 +66,23 @@ def relabel_pyhim_identifiers(csv_data):
     return csv_data
 
 
+def micrometer_scale_from_xyz_unit(xyz_unit):
+    """Return the factor needed to convert an XYZ unit to micrometers."""
+    normalized_unit = xyz_unit.strip().lower().replace("µ", "u")
+    micrometer_units = {"micron", "microns", "micrometer", "micrometers", "um"}
+    nanometer_units = {"nm", "nanometer", "nanometers"}
+
+    if normalized_unit in micrometer_units:
+        return 1.0
+    if normalized_unit in nanometer_units:
+        return 0.001
+
+    raise ValueError(
+        f"Unsupported FOF-CT XYZ_unit '{xyz_unit}'. "
+        "Supported coordinate units are micrometers and nanometers."
+    )
+
+
 def random_label_cmap(n_labels=256, seed=42):
     """
     Generates a random colormap similar to stardist (so you don't have to import this library just to do it).
@@ -207,8 +224,10 @@ class ChromatinTraceTable:
                     self.experimenter_name = line.split(": ")[1].strip()
                 elif line.startswith("#experimenter_contact:"):
                     self.experimenter_contact = line.split(": ")[1].strip()
-                elif line.startswith("##genome_assembly:"):
-                    self.genome_assembly = line.split("=")[1].strip()
+                elif line.startswith("##genome_assembly="):
+                    self.genome_assembly = line.split("=", 1)[1].strip()
+                elif line.startswith("##XYZ_unit="):
+                    self.xyz_unit = line.split("=", 1)[1].strip()
                 elif line.startswith("#Software_Title:"):
                     self.software_title = line.split(": ")[1].strip()
                 elif line.startswith("#Software_Authors:"):
@@ -242,6 +261,17 @@ class ChromatinTraceTable:
 
         # Rename XYZ columns for Astropy compatibility
         csv_data.rename(columns={"X": "x", "Y": "y", "Z": "z"}, inplace=True)
+
+        # pyHiM Astropy trace tables store XYZ coordinates in micrometers.
+        # FOF-CT tables declare their coordinate unit in the ##XYZ_unit header,
+        # so convert when needed before returning the Astropy table.
+        micrometer_scale = micrometer_scale_from_xyz_unit(self.xyz_unit)
+        for coordinate in ("x", "y", "z"):
+            if coordinate in csv_data.columns:
+                csv_data[coordinate] = (
+                    csv_data[coordinate].astype(float) * micrometer_scale
+                )
+        self.xyz_unit = "micron"
 
         # Handle optional Cell_ID column
         if "Cell_ID" in csv_data.columns:
@@ -671,7 +701,9 @@ class ChromatinTraceTable:
             ax1.set_xlabel("barcode IDs", fontsize=18)
 
             # Add colorbar
-            cbar = fig.colorbar(pos, ax=ax1,location="bottom",anchor=(0.5, 1), shrink=0.4)
+            cbar = fig.colorbar(
+                pos, ax=ax1, location="bottom", anchor=(0.5, 1), shrink=0.4
+            )
             cbar.set_label(label, fontsize=label_fontsize)
             cbar.ax.tick_params(labelsize=tick_fontsize)
 


### PR DESCRIPTION
### Motivation
- FOF-CT `.4dn` tables declare coordinate units in a `##XYZ_unit` header but the conversion to pyHiM/astropy previously assumed micrometers, producing incorrect coordinates when the file used nanometers.

### Description
- Added `micrometer_scale_from_xyz_unit()` to normalize supported `XYZ_unit` strings and return the conversion factor to micrometers.
- Updated `_read_metadata_from_4dn()` to parse the `##XYZ_unit=` header into `self.xyz_unit` and to robustly split `##genome_assembly=`.
- Updated `_convert_4dn_to_astropy()` to apply the micrometer scale to `x`, `y`, and `z` columns before building the `astropy.table.Table` and to set `self.xyz_unit` to `"micron"` after conversion.
- Added unit-regression checks in `test/test_trace_merge.py` to assert nanometer-to-micron conversion and to verify micron coordinates pass through unchanged.

### Testing
- Ran formatter with `python -m black traceratops/core/chromatin_trace_table.py test/test_trace_merge.py` which reformatted `traceratops/core/chromatin_trace_table.py` successfully.
- Ran the unit tests with `pytest test/test_trace_merge.py -q`, which completed successfully with `5 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4f679adf3883308a7e45ad1db79dfd)