### PR TITLE
Use maximum thresholds for roundness and spot_pixel_percentage filters

### DIFF
--- a/test/test_trace_filter.py
+++ b/test/test_trace_filter.py
@@ -279,12 +279,67 @@ def test_filter_by_localization_metrics_combines_thresholds():
             "intensity": 10.0,
             "snr": 5.0,
             "object_class": 1,
-            "roundness": 0.6,
         },
+        {"roundness": 0.6},
     )
 
-    assert list(trace.data["Spot_ID"]) == ["spot-1", "spot-4"]
-    assert intensities_kept == [10.0, 12.0]
+    assert list(trace.data["Spot_ID"]) == ["spot-4"]
+    assert intensities_kept == [12.0]
+
+
+def test_args_quality_filters_uses_maximums_for_roundness_and_spot_pixel_percentage():
+    from traceratops.trace_filter import args_quality_filters_to_dict, parse_arguments
+
+    parser = parse_arguments()
+    args = parser.parse_args(
+        [
+            "--input",
+            "trace.ecsv",
+            "--snr_min",
+            "5",
+            "--roundness_max",
+            "0.75",
+            "--spot_pixel_percentage_max",
+            "40",
+        ]
+    )
+
+    assert args_quality_filters_to_dict(args) == {
+        "minimum": {"snr": 5.0},
+        "maximum": {"spot_pixel_percentage": 40.0, "roundness": 0.75},
+    }
+
+
+def test_filter_by_localization_metrics_removes_values_above_maximums():
+    from astropy.table import Table
+    from traceratops.core.chromatin_trace_table import ChromatinTraceTable
+
+    trace = ChromatinTraceTable()
+    trace.data = Table(
+        rows=[
+            ("spot-1", "trace-a", 1),
+            ("spot-2", "trace-a", 2),
+            ("spot-3", "trace-a", 3),
+        ],
+        names=("Spot_ID", "Trace_ID", "Barcode #"),
+    )
+    localizations = Table(
+        rows=[
+            ("spot-1", 0.5, 20.0),
+            ("spot-2", 0.7, 20.0),
+            ("spot-3", 0.5, 45.0),
+        ],
+        names=("Buid", "roundness", "spot_pixel_percentage"),
+    )
+
+    trace.filter_by_localization_metrics(
+        trace,
+        localizations,
+        {},
+        {"roundness": 0.6, "spot_pixel_percentage": 40.0},
+    )
+
+    assert list(trace.data["Spot_ID"]) == ["spot-1"]
 
 
 def test_clean_spots_preserves_reused_spot_ids_across_traces():

--- a/traceratops/core/chromatin_trace_table.py
+++ b/traceratops/core/chromatin_trace_table.py
@@ -559,7 +559,9 @@ class ChromatinTraceTable:
             trace, localizations, {"intensity": intensity_min}
         )
 
-    def filter_by_localization_metrics(self, trace, localizations, minimum_thresholds):
+    def filter_by_localization_metrics(
+        self, trace, localizations, minimum_thresholds, maximum_thresholds=None
+    ):
         """Filter trace rows by one or more localization-table quality thresholds.
 
         Parameters
@@ -573,18 +575,26 @@ class ChromatinTraceTable:
             The special ``intensity`` key keeps backward-compatible behavior by
             resolving to ``mean_intensity`` in new tables or ``peak`` in legacy
             tables.
+        maximum_thresholds : dict, optional
+            Mapping of localization-table metric names to maximum values to keep.
         """
-        thresholds = {
+        minimum_thresholds = {
             metric: minimum
             for metric, minimum in minimum_thresholds.items()
             if minimum is not None
         }
-        if not thresholds:
+        maximum_thresholds = {
+            metric: maximum
+            for metric, maximum in (maximum_thresholds or {}).items()
+            if maximum is not None
+        }
+        if not minimum_thresholds and not maximum_thresholds:
             return []
 
         localizations.add_index("Buid")  # Add an index for fast lookup
-        resolved_thresholds = {}
-        for metric, minimum in thresholds.items():
+        resolved_minimum_thresholds = {}
+        resolved_maximum_thresholds = {}
+        for metric, minimum in minimum_thresholds.items():
             column_name = (
                 self._get_localization_intensity_column(localizations)
                 if metric == "intensity"
@@ -595,14 +605,27 @@ class ChromatinTraceTable:
                     f"Localization table must contain a '{column_name}' column "
                     f"to filter by '{metric}'."
                 )
-            resolved_thresholds[column_name] = minimum
+            resolved_minimum_thresholds[column_name] = minimum
+
+        for metric, maximum in maximum_thresholds.items():
+            column_name = (
+                self._get_localization_intensity_column(localizations)
+                if metric == "intensity"
+                else metric
+            )
+            if column_name not in localizations.colnames:
+                raise KeyError(
+                    f"Localization table must contain a '{column_name}' column "
+                    f"to filter by '{metric}'."
+                )
+            resolved_maximum_thresholds[column_name] = maximum
 
         rows_to_remove = []
         number_spots = len(trace.data)
         intensities_kept = list()
         intensity_column = (
             self._get_localization_intensity_column(localizations)
-            if "intensity" in thresholds
+            if "intensity" in minimum_thresholds or "intensity" in maximum_thresholds
             else None
         )
 
@@ -614,10 +637,15 @@ class ChromatinTraceTable:
                 continue  # If Spot_ID is not found, keep the entry
 
             remove_row = False
-            for column_name, minimum in resolved_thresholds.items():
+            for column_name, minimum in resolved_minimum_thresholds.items():
                 if localization[column_name] < minimum:
                     remove_row = True
                     break
+            if not remove_row:
+                for column_name, maximum in resolved_maximum_thresholds.items():
+                    if localization[column_name] > maximum:
+                        remove_row = True
+                        break
 
             if remove_row:
                 rows_to_remove.append(idx)
@@ -626,11 +654,17 @@ class ChromatinTraceTable:
 
         trace.data.remove_rows(rows_to_remove)
         threshold_summary = ", ".join(
-            f"{column_name}>={minimum}"
-            for column_name, minimum in resolved_thresholds.items()
+            [
+                f"{column_name}>={minimum}"
+                for column_name, minimum in resolved_minimum_thresholds.items()
+            ]
+            + [
+                f"{column_name}<={maximum}"
+                for column_name, maximum in resolved_maximum_thresholds.items()
+            ]
         )
         print(
-            f"> Removed {len(rows_to_remove)}/{number_spots} localizations below localization quality thresholds ({threshold_summary})."
+            f"> Removed {len(rows_to_remove)}/{number_spots} localizations outside localization quality thresholds ({threshold_summary})."
         )
         print(f"> Number of rows in filtered trace table: {len(trace.data)}")
 

--- a/traceratops/trace_filter.py
+++ b/traceratops/trace_filter.py
@@ -40,7 +40,7 @@ The script can process single files or multiple files via pipe input.
     $ trace_filter --input Trace.ecsv --remove_label region1
 
     # Filter by localization quality metrics
-    $ trace_filter --input Trace.ecsv --localization_file Localizations.ecsv --intensity_min 1000 --snr_min 5 --object_class_min 1
+    $ trace_filter --input Trace.ecsv --localization_file Localizations.ecsv --intensity_min 1000 --snr_min 5 --object_class_min 1 --roundness_max 0.8
 
     # Process multiple files via pipe
     $ ls *Trace.ecsv | trace_filter --pipe --n_barcodes 3
@@ -131,19 +131,19 @@ def parse_arguments():
         default=0.0,
         help="Minimum intensity threshold for localizations. Uses mean_intensity for new localization tables and peak for legacy tables.",
     )
-    for metric in (
-        "snr",
-        "spot_pixel_percentage",
-        "skew",
-        "patch_size",
-        "object_class",
-        "roundness",
-    ):
+    for metric in ("snr", "skew", "patch_size", "object_class"):
         psr_intensity.add_argument(
             f"--{metric}_min",
             type=float,
             default=0.0,
             help=f"Minimum {metric} threshold for localizations.",
+        )
+    for metric in ("spot_pixel_percentage", "roundness"):
+        psr_intensity.add_argument(
+            f"--{metric}_max",
+            type=float,
+            default=0.0,
+            help=f"Maximum {metric} threshold for localizations.",
         )
 
     psr_coord = parser.add_argument_group(
@@ -183,15 +183,24 @@ def args_coord_to_dict(args):
 
 
 def args_quality_filters_to_dict(args):
-    quality_filters = {
+    minimum_filters = {
         "snr": args.snr_min,
-        "spot_pixel_percentage": args.spot_pixel_percentage_min,
         "skew": args.skew_min,
         "patch_size": args.patch_size_min,
         "object_class": args.object_class_min,
-        "roundness": args.roundness_min,
     }
-    return {metric: minimum for metric, minimum in quality_filters.items() if minimum}
+    maximum_filters = {
+        "spot_pixel_percentage": args.spot_pixel_percentage_max,
+        "roundness": args.roundness_max,
+    }
+    return {
+        "minimum": {
+            metric: minimum for metric, minimum in minimum_filters.items() if minimum
+        },
+        "maximum": {
+            metric: maximum for metric, maximum in maximum_filters.items() if maximum
+        },
+    }
 
 
 def get_files_from_args(args):
@@ -278,8 +287,10 @@ def runtime(
         )
 
     quality_filters = quality_filters or {}
+    minimum_filters = quality_filters.get("minimum", quality_filters)
+    maximum_filters = quality_filters.get("maximum", {})
     if intensity_min:
-        quality_filters["intensity"] = intensity_min
+        minimum_filters["intensity"] = intensity_min
 
     localizations_data = None
     if localizations_file:
@@ -342,9 +353,9 @@ def runtime(
 
         # removes localizations that do not satisfy localization quality thresholds
         print("\n$ Filtering barcodes based on localization quality")
-        if quality_filters and localizations_file:
+        if (minimum_filters or maximum_filters) and localizations_file:
             intensities_kept = trace.filter_by_localization_metrics(
-                trace, localizations_data, quality_filters
+                trace, localizations_data, minimum_filters, maximum_filters
             )
             if intensity_min:
                 output_file = trace_file.split(".")[0]
@@ -352,7 +363,7 @@ def runtime(
                     intensities_kept,
                     output_file=f"{output_file}_filtered_intensities.{output_format}",
                 )
-        elif quality_filters and not localizations_file:
+        elif (minimum_filters or maximum_filters) and not localizations_file:
             print("! Localization quality filters require --localization_file; skipping.")
 
         print("\n$ Filtering barcode number")


### PR DESCRIPTION
### Motivation
- The roundness and spot_pixel_percentage localization metrics were previously treated as minimum thresholds but should instead be provided as maximum thresholds so spots with higher values are removed. 
- Update the CLI and filtering logic to support both minimum and maximum localization-quality thresholds so behavior is consistent and explicit.

### Description
- Replace the CLI options `--roundness_min` and `--spot_pixel_percentage_min` with `--roundness_max` and `--spot_pixel_percentage_max` and keep other metrics as minimums by updating `parse_arguments()` in `traceratops/trace_filter.py`.
- Change `args_quality_filters_to_dict()` to return separate `"minimum"` and `"maximum"` dicts and wire those through `runtime()` so both kinds of thresholds are available at runtime.
- Extend `ChromatinTraceTable.filter_by_localization_metrics()` signature to accept `maximum_thresholds` and implement logic to remove rows where any metric is below a minimum or above a maximum, updating the threshold summary message; changes are in `traceratops/core/chromatin_trace_table.py`.
- Add and adjust tests in `test/test_trace_filter.py` to cover parsing of the new max flags, combined min/max behavior, and removal of values above maximums.

### Testing
- Ran `pytest -q test/test_trace_filter.py`, which passed (new and updated tests succeeded). 
- Ran full test suite with `pytest -q`, which completed successfully with `103 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a509691c378833087681951654545c7)