### PR TITLE
Document max-quality filters and output filtered localizations in trace_filter

### DIFF
--- a/docs/source/scripts/trace/trace_filter.md
+++ b/docs/source/scripts/trace/trace_filter.md
@@ -5,23 +5,38 @@
 ## Localization quality filtering
 
 `trace_filter` can remove spots by comparing values in a localization table
-against user-provided minimum thresholds. Pass the localization table with
-`--localization_file`, then add any combination of quality filters:
+against user-provided quality thresholds. Pass the localization table with
+`--localization_file`, then add any combination of quality filters.
+
+Minimum-threshold filters remove spots whose value is smaller than the provided
+threshold:
 
 - `--intensity_min`: minimum spot intensity. This single argument supports both
   localization-table formats: it filters on `mean_intensity` when that column is
   present in newer tables, or on `peak` for legacy tables.
 - `--snr_min`: minimum `snr`.
-- `--spot_pixel_percentage_min`: minimum `spot_pixel_percentage`.
 - `--skew_min`: minimum `skew`.
 - `--patch_size_min`: minimum `patch_size`.
-- `--roundness_min`: minimum `roundness`.
 - `--object_class_min`: minimum `object_class`; use `--object_class_min 1` to
   keep spots classified as spots (`object_class >= 1`) and remove background
   localizations (`object_class == 0`).
 
+Maximum-threshold filters remove spots whose value is larger than the provided
+threshold:
+
+- `--spot_pixel_percentage_max`: maximum `spot_pixel_percentage`.
+- `--roundness_max`: maximum `roundness`.
+
 When multiple quality filters are provided, a spot is kept only if it satisfies
-all requested minimum thresholds.
+all requested thresholds. In other words, it must be greater than or equal to
+each requested minimum and less than or equal to each requested maximum.
+
+When a localization table is provided, `trace_filter` also writes a filtered
+localization table next to the filtered trace table. This table contains only the
+localizations whose `Buid` values are present as `Spot_ID` values in the final
+filtered trace table, after all trace filters have run. The same filtered
+localization table is used for the `*_localization_distribution_fluxes` plot, so
+that the spot statistics describe the spots kept in the trace table.
 
 Example:
 
@@ -31,7 +46,9 @@ trace_filter \
   --localization_file Localizations.ecsv \
   --intensity_min 1000 \
   --snr_min 5 \
-  --object_class_min 1
+  --object_class_min 1 \
+  --spot_pixel_percentage_max 0.7 \
+  --roundness_max 0.8
 ```
 
 ```{eval-rst}

--- a/traceratops/trace_filter.py
+++ b/traceratops/trace_filter.py
@@ -50,6 +50,7 @@ The script can process single files or multiple files via pipe input.
 
 from traceratops.script_banner import print_script_banner
 import argparse
+import os
 import sys
 
 import numpy as np
@@ -260,6 +261,24 @@ def filter_label(label_to_keep, label_to_remove, trace):
     return trace, file_tag
 
 
+def get_filtered_localizations(localizations_data, trace_data):
+    """Return localizations whose ``Buid`` is still present in the trace table."""
+    if localizations_data is None or trace_data is None or len(trace_data) == 0:
+        return localizations_data[:0]
+
+    remaining_spot_ids = {str(spot_id) for spot_id in trace_data["Spot_ID"]}
+    rows_to_keep = [
+        str(localization_id) in remaining_spot_ids
+        for localization_id in localizations_data["Buid"]
+    ]
+    return localizations_data[rows_to_keep]
+
+
+def get_file_root(file_name):
+    """Return a file path without its final extension."""
+    return os.path.splitext(file_name)[0]
+
+
 def runtime(
     trace_files=[],
     n_barcodes=2,
@@ -305,7 +324,7 @@ def runtime(
             localizations_data
         )
         intensities = [row[intensity_column] for row in localizations_data]
-        output_file = localizations_file.split(".")[0]
+        output_file = get_file_root(localizations_file)
         localization_table.plot_intensity_distribution(
             intensities,
             output_file=f"{output_file}_localization_intensities.{output_format}",
@@ -358,7 +377,7 @@ def runtime(
                 trace, localizations_data, minimum_filters, maximum_filters
             )
             if intensity_min:
-                output_file = trace_file.split(".")[0]
+                output_file = get_file_root(trace_file)
                 localization_table.plot_intensity_distribution(
                     intensities_kept,
                     output_file=f"{output_file}_filtered_intensities.{output_format}",
@@ -370,9 +389,29 @@ def runtime(
         trace, comments = filter_barcode_number(n_barcodes, trace, comments)
 
         # saves output trace
-        outputfile = trace_file.split(".")[0] + "_" + tag + file_tag + ".ecsv"
+        output_root = get_file_root(trace_file) + "_" + tag + file_tag
+        outputfile = output_root + ".ecsv"
         trace.save(outputfile, comments=", ".join(comments))
         print(f"$ Saved output trace file at: {outputfile}")
+
+        if localizations_file:
+            filtered_localizations = get_filtered_localizations(
+                localizations_data, trace.data
+            )
+            localization_outputfile = output_root + "_localizations.ecsv"
+            localization_table.save(
+                localization_outputfile,
+                filtered_localizations,
+                comments="localizations kept in filtered trace table",
+            )
+            print(
+                "$ Saved filtered localization table with "
+                f"{len(filtered_localizations)} rows at: {localization_outputfile}"
+            )
+            localization_table.plot_distribution_fluxes(
+                filtered_localizations,
+                [f"{output_root}_localization_distribution_fluxes.{output_format}"],
+            )
     return len(trace_files)
 
 


### PR DESCRIPTION
### Motivation
- Clarify that some localization-quality filters are maximum thresholds rather than minimums so documentation matches current runtime behavior.
- Produce a localization table that reflects only the spots remaining after trace filtering so statistics and plots describe the kept spots.

### Description
- Updated documentation in `docs/source/scripts/trace/trace_filter.md` to describe minimum thresholds (`--snr_min`, `--skew_min`, `--patch_size_min`, `--object_class_min`, `--intensity_min`) and maximum thresholds (`--spot_pixel_percentage_max`, `--roundness_max`) and to note that both types combine conjunctively.
- Added `get_filtered_localizations` to `traceratops/trace_filter.py` to subset the localization table to rows whose `Buid` is present as `Spot_ID` in the final filtered trace table.
- Modified `runtime` in `traceratops/trace_filter.py` to save a filtered localization file next to the filtered trace and to call `LocalizationTable.plot_distribution_fluxes` with the filtered-localizations table so the distribution plot describes the kept spots; also added `get_file_root` and `import os` to make output-root handling robust.

### Testing
- Ran `git diff --check` with no issues reported.
- Ran `python -m py_compile traceratops/trace_filter.py` with successful compilation.
- Executed a synthetic unit-like test calling `get_filtered_localizations` which passed.
- Performed an end-to-end synthetic CLI run (via `MPLBACKEND=Agg python -m traceratops.trace_filter` with small temporary trace and localization files) that validated the filtered trace output, the filtered localization file, and the produced `*_localization_distribution_fluxes` plot; the run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a509b4b5e70833091ca67d44ecfd2bc)