### PR TITLE
Add uv-based installation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,25 +26,22 @@ The package is intended for users who already have pyHiM-style localization or t
 
 ## Installation
 
-traceratops supports Linux, macOS, and Windows. We recommend installing it in a dedicated conda environment:
+traceratops supports Linux, macOS, and Windows. We recommend installing it in a dedicated `uv` environment. For a development installation, use the bundled installer:
 
 ```bash
-conda create -n traceratops python=3.11
-conda activate traceratops
+curl -O https://raw.githubusercontent.com/pyHi-M/traceratops/main/install_traceratops_uv.bash
+bash install_traceratops_uv.bash
+source $HOME/Repositories/traceratops/.venv/bin/activate
 ```
 
-Clone the repository and install the package:
+To install manually with `uv`, clone the repository and install the development environment:
 
 ```bash
 git clone https://github.com/pyHi-M/traceratops.git
 cd traceratops
-pip install -e .
-```
-
-For development and documentation work, install the optional development dependencies:
-
-```bash
-pip install -e '.[dev]'
+uv venv .venv --python 3.11
+source .venv/bin/activate
+uv pip install -e ".[dev]"
 ```
 
 After installation, traceratops command-line tools such as `trace_filter`, `trace_merge`, `trace_to_matrix`, `trace_stats`, `plot_him_matrix`, and `localization_analyzer` should be available in the active environment.

--- a/docs/source/contribute/dev_installation.md
+++ b/docs/source/contribute/dev_installation.md
@@ -1,21 +1,57 @@
-
 # Installation [DEV]
 
-## Create conda environment
+The recommended development setup uses [`uv`](https://docs.astral.sh/uv/) for both the virtual environment and package installation. The repository includes `install_traceratops_uv.bash`, which installs `uv` if needed, clones traceratops, creates a fresh `.venv`, installs traceratops with development dependencies, and runs a small import/CLI check.
+
+## Automated uv installation
+
+From any terminal, run:
 
 ```bash
-conda create -n traceratops python=3.11
-conda activate traceratops
+curl -O https://raw.githubusercontent.com/pyHi-M/traceratops/main/install_traceratops_uv.bash
+bash install_traceratops_uv.bash
 ```
 
-## Download & install the source code
+By default, the script:
+
+- clones traceratops into `$HOME/Repositories/traceratops`;
+- creates a fresh uv environment at `$HOME/Repositories/traceratops/.venv`;
+- uses Python 3.11;
+- installs traceratops in editable mode with the `dev` optional dependencies;
+- checks that core scientific dependencies and the `trace_filter` command are available.
+
+Activate the environment after installation with:
 
 ```bash
-cd $HOME/Repositories
-git clone git@github.com:pyHi-M/traceratops.git
+source $HOME/Repositories/traceratops/.venv/bin/activate
+```
 
-cd $HOME/Repositories/traceratops
-pip install -e ".[dev]"
+## Manual uv installation
+
+If you prefer to run the commands yourself, install `uv` first if it is missing:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+Then clone and install traceratops:
+
+```bash
+mkdir -p $HOME/Repositories
+cd $HOME/Repositories
+git clone https://github.com/pyHi-M/traceratops.git
+cd traceratops
+uv venv .venv --python 3.11
+source .venv/bin/activate
+uv pip install -e ".[dev]"
+```
+
+
+## Check the installation
+
+```bash
+python -c "import traceratops; print('traceratops OK')"
+trace_filter --help
 ```
 
 ## [Recommended] Setup pre-commit in local
@@ -61,22 +97,11 @@ pip install -e ".[dev]"
 
 ## Strange error
 
-- If you get things like this during the installation:
-
-```rest
-ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
-pylint 2.12.2 requires isort<6,>=4.2.5, which is not installed.
-pylint 2.12.2 requires mccabe<0.7,>=0.6, which is not installed.
-pylint 2.12.2 requires toml>=0.9.2, which is not installed.
-```
-
-**OR**
-
 - If a script name seems to refer to another package:
 
-  - Identify the error package name (here it's pylint).
-  - If it's not in the dependancies of your project, it's a "ghost".
+  - Identify the error package name.
+  - If it's not in the dependencies of your project, it's a "ghost".
   - To exorcise it:
-    - Identify exe path : `which pylint` (give me `/home/user/.local/bin/pylint`)
+    - Identify exe path : `which pylint` (for example `/home/user/.local/bin/pylint`)
     - Remove it : `rm ~/.local/bin/pylint`
-  - Re-install your package to be sure `pip install -e ".[dev]"`
+  - Re-install your package to be sure `uv pip install -e ".[dev]"`

--- a/docs/source/quickstart/installation.md
+++ b/docs/source/quickstart/installation.md
@@ -4,35 +4,35 @@
 |:-:|:-:|:-:|:-:|
 |**compatibility**|Yes|Yes|Yes|
 
-## Install conda (virtual environment manager)
+## Install uv (virtual environment manager)
 
-*We use conda environment to avoid version problem with other application dependencies.*
+*We use `uv` environments to avoid version problems with other application dependencies and to keep installation commands reproducible.*
 
-We recommend to download the lighter version `miniconda`.
-
-- [Installing miniconda](https://www.anaconda.com/docs/getting-started/miniconda/install#quickstart-install-instructions)
-
-- [Installing anaconda distribution](https://www.anaconda.com/docs/getting-started/anaconda/install#basic-install-instructions)
-
-## Create conda environment
-
-Open a **terminal** (for Windows user: from the Start menu, open the **Anaconda Prompt**). Create a conda environment and activate it:
-```
-conda create -n traceratops python=3.11
-conda activate traceratops
-```
-
-## Download the source code
+If `uv` is not installed yet, install it with:
 
 ```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+## Automated installation
+
+The fastest way to install traceratops from source is to run the bundled uv installer:
+
+```bash
+curl -O https://raw.githubusercontent.com/pyHi-M/traceratops/main/install_traceratops_uv.bash
+bash install_traceratops_uv.bash
+source $HOME/Repositories/traceratops/.venv/bin/activate
+```
+
+## Manual installation
+
+```bash
+mkdir -p $HOME/Repositories
 cd $HOME/Repositories
 git clone https://github.com/pyHi-M/traceratops.git
-```
-
-
-## Install package
-
-```bash
-cd $HOME/Repositories/traceratops
-pip install -e .
+cd traceratops
+uv venv .venv --python 3.11
+source .venv/bin/activate
+uv pip install -e ".[dev]"
 ```

--- a/install_traceratops_uv.bash
+++ b/install_traceratops_uv.bash
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# -----------------------------
+# User settings
+# -----------------------------
+
+REPO_DIR="${HOME}/Repositories"
+PYTHON_VERSION="3.11"
+REPO_URL="https://github.com/pyHi-M/traceratops.git"
+
+# -----------------------------
+# Install uv if missing
+# -----------------------------
+
+if ! command -v uv >/dev/null 2>&1; then
+    echo "Installing uv..."
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    export PATH="${HOME}/.local/bin:${PATH}"
+else
+    echo "uv already installed."
+fi
+
+# -----------------------------
+# Clone repository
+# -----------------------------
+
+mkdir -p "${REPO_DIR}"
+cd "${REPO_DIR}"
+
+if [ ! -d "traceratops" ]; then
+    git clone "${REPO_URL}"
+else
+    echo "traceratops repository already exists."
+fi
+
+# -----------------------------
+# Create fresh uv environment
+# -----------------------------
+
+cd "${REPO_DIR}/traceratops"
+
+if [ -d ".venv" ]; then
+    echo "Removing existing .venv..."
+    rm -rf .venv
+fi
+
+uv venv .venv --python "${PYTHON_VERSION}"
+source .venv/bin/activate
+
+# -----------------------------
+# Install traceratops with development dependencies
+# -----------------------------
+
+uv pip install -e ".[dev]"
+
+# -----------------------------
+# Test installation
+# -----------------------------
+
+python -c "import numpy, scipy, astropy; print('numpy', numpy.__version__); print('scipy', scipy.__version__); print('astropy', astropy.__version__)"
+python -c "import traceratops; print('traceratops OK')"
+trace_filter --help >/dev/null
+
+cat <<EOM
+
+Installation complete.
+Activate with:
+source ${REPO_DIR}/traceratops/.venv/bin/activate
+
+Test traceratops with:
+trace_filter --help
+EOM


### PR DESCRIPTION
### Motivation
- Provide a reproducible, `uv`-centric development install workflow so contributors can create and manage an isolated environment without conda.
- Offer a single automated installer that sets up `uv`, creates a fresh `.venv`, installs the package with development dependencies, and performs basic runtime/CLI checks.
- Align traceratops onboarding with the uv-based workflow used by related projects to simplify developer setup and documentation.

### Description
- Add `install_traceratops_uv.bash`, an executable script that installs `uv` if missing, clones the repository, creates a Python 3.11 `.venv` via `uv venv`, activates it, installs the project with dev extras using `uv pip install -e ".[dev]"`, and runs small import/CLI checks.
- Update `README.md` to recommend the bundled `uv` installer and show manual `uv` commands as an alternative to the previous conda instructions.
- Update `docs/source/contribute/dev_installation.md` to document both the automated installer (`install_traceratops_uv.bash`) and manual `uv` installation steps and to show how to check the installation.
- Update `docs/source/quickstart/installation.md` to replace conda instructions with `uv`-based automated and manual installation guidance and adjust error/help text to reference `uv` usage.

### Testing
- Ran `git diff --check` to validate whitespace and diff issues, which succeeded.
- Performed a syntax check on the new script with `bash -n install_traceratops_uv.bash`, which succeeded.
- Compiled package sources with `python -m compileall traceratops` to ensure no syntax errors, which succeeded.
- Attempted to validate the full `uv` installation (`uv run/uv sync` and `uv pip install -e ".[dev]"`) inside this environment but the install could not be completed here due to a `uv.lock` parsing issue or inability to reach PyPI, so a full end-to-end install could not be verified in this CI-like environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a523d5063788330adb9f87f2bdabbf3)