### PR TITLE
Use trace-centered hexbins for projection plots

### DIFF
--- a/test/data/trace_filter/IN/duplicate_spot_intensity_localizations.ecsv
+++ b/test/data/trace_filter/IN/duplicate_spot_intensity_localizations.ecsv
@@ -1,0 +1,25 @@
+# %ECSV 1.0
+# ---
+# datatype:
+# - {name: Buid, datatype: string}
+# - {name: 'ROI #', datatype: int64}
+# - {name: 'CellID #', datatype: int64}
+# - {name: 'Barcode #', datatype: int64}
+# - {name: id, datatype: int64}
+# - {name: zcentroid, datatype: float32}
+# - {name: xcentroid, datatype: float32}
+# - {name: ycentroid, datatype: float32}
+# - {name: sharpness, datatype: float32}
+# - {name: roundness1, datatype: float32}
+# - {name: roundness2, datatype: float32}
+# - {name: npix, datatype: int64}
+# - {name: sky, datatype: float32}
+# - {name: peak, datatype: float32}
+# - {name: flux, datatype: float32}
+# - {name: mag, datatype: float32}
+# meta: !!omap
+# - comments: [localizations kept in filtered trace table]
+# schema: astropy-2.0
+Buid "ROI #" "CellID #" "Barcode #" id zcentroid xcentroid ycentroid sharpness roundness1 roundness2 npix sky peak flux mag
+0000005 5 0 22 4 8.0 201.0 62.0 0.41 7.98 0.41 260 0.0 570.0 11300.0 -10.3
+0000007 5 0 24 6 8.0 203.0 62.0 0.39 7.9 0.39 250 0.0 590.0 11500.0 -10.5

--- a/traceratops/trace_analyzer.py
+++ b/traceratops/trace_analyzer.py
@@ -523,7 +523,8 @@ def plot_kde_projections(trace_table, output_filename, target_ratio=0.5):
     trace_table : astropy.table.Table
     output_filename : str
     target_ratio : float
-        Controls mild Z stretching
+        Deprecated; retained for backward compatibility. Projection axes are
+        displayed with the same automatically calculated range.
     """
     with matplotlib.rc_context({"font.size": 10}):
         relative_coordinates = []
@@ -544,34 +545,42 @@ def plot_kde_projections(trace_table, output_filename, target_ratio=0.5):
         y = xyz[:, 1]
         z = xyz[:, 2]
 
-        # === Z scaling (mild) ===
-        x_range = x.max() - x.min()
-        y_range = y.max() - y.min()
-        z_range = z.max() - z.min()
+        coordinate_ranges = {
+            "x": x.max() - x.min(),
+            "y": y.max() - y.min(),
+            "z": z.max() - z.min(),
+        }
+        shared_range = max(coordinate_ranges.values())
+        if shared_range == 0:
+            shared_range = 1
 
-        xy_range = 0.5 * (x_range + y_range)
-        z_scale = (xy_range * target_ratio) / z_range if z_range > 0 else 1
-        z_scaled = z * z_scale
+        def _axis_limits(coordinates):
+            midpoint = 0.5 * (coordinates.max() + coordinates.min())
+            half_range = 0.5 * shared_range
+            return (midpoint - half_range, midpoint + half_range)
 
-        def _plot(ax, x_values, y_values, xlabel, ylabel, title, show_z_ticks=False):
+        x_limits = _axis_limits(x)
+        y_limits = _axis_limits(y)
+        z_limits = _axis_limits(z)
+
+        def _plot(ax, x_values, y_values, xlabel, ylabel, title, axis_limits):
+            x_axis_limits, y_axis_limits = axis_limits
             hexbins = ax.hexbin(
                 x_values,
                 y_values,
                 gridsize=45,
                 mincnt=1,
                 cmap="cubehelix_r",
+                extent=(*x_axis_limits, *y_axis_limits),
             )
 
             ax.set_xlabel(xlabel)
             ax.set_ylabel(ylabel)
             ax.set_title(title)
+            ax.set_xlim(x_axis_limits)
+            ax.set_ylim(y_axis_limits)
             ax.set_aspect("equal")
             ax.grid(alpha=0.3)
-
-            if show_z_ticks:
-                z_ticks = np.arange(np.floor(z.min()), np.ceil(z.max()) + 1, 1)
-                ax.set_yticks(z_ticks * z_scale)
-                ax.set_yticklabels([f"{int(t)}" for t in z_ticks])
 
             return hexbins
 
@@ -584,14 +593,16 @@ def plot_kde_projections(trace_table, output_filename, target_ratio=0.5):
         ax_yz = fig.add_subplot(gs[1, 1])
         cax = fig.add_subplot(gs[:, 2])
 
-        im = _plot(ax_xy, x, y, "X (µm)", "Y (µm)", "XY projection")
-
-        _plot(
-            ax_xz, x, z_scaled, "X (µm)", "Z (µm)", "XZ projection", show_z_ticks=True
+        im = _plot(
+            ax_xy, x, y, "X (µm)", "Y (µm)", "XY projection", (x_limits, y_limits)
         )
 
         _plot(
-            ax_yz, y, z_scaled, "Y (µm)", "Z (µm)", "YZ projection", show_z_ticks=True
+            ax_xz, x, z, "X (µm)", "Z (µm)", "XZ projection", (x_limits, z_limits)
+        )
+
+        _plot(
+            ax_yz, y, z, "Y (µm)", "Z (µm)", "YZ projection", (y_limits, z_limits)
         )
 
         cbar = fig.colorbar(im, cax=cax)

--- a/traceratops/trace_analyzer.py
+++ b/traceratops/trace_analyzer.py
@@ -13,7 +13,6 @@ import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.gridspec import GridSpec
-from scipy.stats import gaussian_kde
 
 from traceratops.core.chromatin_trace_table import ChromatinTraceTable
 from traceratops.script_banner import print_script_banner
@@ -512,22 +511,12 @@ def barcode_detection_efficiency(
     print(f"$ Exporting barcode detection plot to: {output_prefix}.{format}")
 
 
-def compute_kde(x, y, grid_size=200):
-    xy = np.vstack([x, y])
-    kde = gaussian_kde(xy)
-
-    xi, yi = np.meshgrid(
-        np.linspace(x.min(), x.max(), grid_size),
-        np.linspace(y.min(), y.max(), grid_size),
-    )
-
-    zi = kde(np.vstack([xi.ravel(), yi.ravel()]))
-    return zi.reshape(xi.shape)
-
-
 def plot_kde_projections(trace_table, output_filename, target_ratio=0.5):
     """
-    Plot KDE projections (XY, XZ, YZ) from trace data.
+    Plot hexbin projections (XY, XZ, YZ) from trace-centered data.
+
+    Each trace is centered independently by subtracting its XYZ center of mass
+    before all spot coordinates are pooled for projection plots.
 
     Parameters
     ----------
@@ -537,9 +526,23 @@ def plot_kde_projections(trace_table, output_filename, target_ratio=0.5):
         Controls mild Z stretching
     """
     with matplotlib.rc_context({"font.size": 10}):
-        x = np.array(trace_table["x"])
-        y = np.array(trace_table["y"])
-        z = np.array(trace_table["z"])
+        relative_coordinates = []
+        trace_by_ID = trace_table.group_by("Trace_ID")
+
+        for sub_trace_table in trace_by_ID.groups:
+            trace_coordinates = np.column_stack(
+                (sub_trace_table["x"], sub_trace_table["y"], sub_trace_table["z"])
+            ).astype(float)
+            center_of_mass = np.mean(trace_coordinates, axis=0)
+            relative_coordinates.append(trace_coordinates - center_of_mass)
+
+        if not relative_coordinates:
+            raise ValueError("Cannot plot projections for an empty trace table")
+
+        xyz = np.vstack(relative_coordinates)
+        x = xyz[:, 0]
+        y = xyz[:, 1]
+        z = xyz[:, 2]
 
         # === Z scaling (mild) ===
         x_range = x.max() - x.min()
@@ -547,17 +550,15 @@ def plot_kde_projections(trace_table, output_filename, target_ratio=0.5):
         z_range = z.max() - z.min()
 
         xy_range = 0.5 * (x_range + y_range)
-
-        z_scale = (xy_range * target_ratio) / z_range
+        z_scale = (xy_range * target_ratio) / z_range if z_range > 0 else 1
         z_scaled = z * z_scale
 
-        def _plot(ax, x, y, xlabel, ylabel, title, show_z_ticks=False):
-            zi = compute_kde(x, y)
-
-            im = ax.imshow(
-                zi,
-                origin="lower",
-                extent=[x.min(), x.max(), y.min(), y.max()],
+        def _plot(ax, x_values, y_values, xlabel, ylabel, title, show_z_ticks=False):
+            hexbins = ax.hexbin(
+                x_values,
+                y_values,
+                gridsize=45,
+                mincnt=1,
                 cmap="cubehelix_r",
             )
 
@@ -572,7 +573,7 @@ def plot_kde_projections(trace_table, output_filename, target_ratio=0.5):
                 ax.set_yticks(z_ticks * z_scale)
                 ax.set_yticklabels([f"{int(t)}" for t in z_ticks])
 
-            return im
+            return hexbins
 
         # === FIGURE ===
         fig = plt.figure(figsize=(12, 8))
@@ -594,9 +595,9 @@ def plot_kde_projections(trace_table, output_filename, target_ratio=0.5):
         )
 
         cbar = fig.colorbar(im, cax=cax)
-        cbar.set_label("Probability density")
+        cbar.set_label("Spot count")
 
-        fig.suptitle("Trace projections", fontsize=30)
+        fig.suptitle("Trace-centered projections", fontsize=30)
 
         fig.subplots_adjust(
             left=0.07, right=0.92, top=0.88, bottom=0.08, wspace=0.25, hspace=0.15

--- a/traceratops/trace_analyzer.py
+++ b/traceratops/trace_analyzer.py
@@ -545,17 +545,18 @@ def plot_kde_projections(trace_table, output_filename, target_ratio=0.5):
         y = xyz[:, 1]
         z = xyz[:, 2]
 
+        scaling_factor=3
         coordinate_ranges = {
-            "x": x.max() - x.min(),
-            "y": y.max() - y.min(),
-            "z": z.max() - z.min(),
+            "x": scaling_factor*(np.std(x.max() - x.min())),
+            "y": scaling_factor*(np.std(y.max() - y.min())),
+            "z": scaling_factor*(np.std(z.max() - z.min())),
         }
         shared_range = max(coordinate_ranges.values())
         if shared_range == 0:
             shared_range = 1
 
         def _axis_limits(coordinates):
-            midpoint = 0.5 * (coordinates.max() + coordinates.min())
+            midpoint = 0.0 #0.5 * (coordinates.max() + coordinates.min())
             half_range = 0.5 * shared_range
             return (midpoint - half_range, midpoint + half_range)
 
@@ -586,7 +587,7 @@ def plot_kde_projections(trace_table, output_filename, target_ratio=0.5):
 
         # === FIGURE ===
         fig = plt.figure(figsize=(12, 8))
-        gs = GridSpec(2, 3, width_ratios=[1, 1, 0.05], hspace=0.05, wspace=0.200)
+        gs = GridSpec(2, 3, width_ratios=[1, 1, 0.05], hspace=0.25, wspace=0.05)
 
         ax_xy = fig.add_subplot(gs[:, 0])
         ax_xz = fig.add_subplot(gs[0, 1])
@@ -606,7 +607,7 @@ def plot_kde_projections(trace_table, output_filename, target_ratio=0.5):
         )
 
         cbar = fig.colorbar(im, cax=cax)
-        cbar.set_label("Spot count")
+        cbar.set_label("density")
 
         fig.suptitle("Trace-centered projections", fontsize=30)
 


### PR DESCRIPTION
### Motivation
- Replace the existing image/KDE-based projection heatmaps with hexbin maps to match the neighbor-distance visualization style and colormap.
- Plot distributions after removing per-trace global shifts by centering each trace on its XYZ center of mass so pooled projections reflect relative spot organization.
- Make projection plots more consistent and interpretable by using the same hexbin parameters and colormap as `_plot_neighbor_hexbin`.

### Description
- Change `plot_kde_projections` to group the input `trace_table` by `Trace_ID`, compute the center of mass for each trace, subtract it from that trace's spot coordinates, and pool the relative coordinates for plotting.
- Replace the KDE-based workflow (removed the `compute_kde` usage and the `gaussian_kde` import) with `ax.hexbin(..., gridsize=45, mincnt=1, cmap="cubehelix_r")` for XY, XZ and YZ projections.
- Add a safe guard for zero Z-range when computing `z_scale`, and use the scaled Z values for the XZ/YZ plots.
- Update plot labels and the colorbar to reflect spot counts and change the figure title to `Trace-centered projections`.

### Testing
- Ran `python -m compileall traceratops/trace_analyzer.py` which completed successfully.
- Ran `pytest -q` which passed with `103 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a54a5a06ba083309fe1d33e2bf5c4c1)