### PR TITLE
Fix trace_plot --number_traces to export first N traces (avoid no-output bug)

### DIFF
--- a/docs/source/scripts/trace/trace_plot.md
+++ b/docs/source/scripts/trace/trace_plot.md
@@ -63,9 +63,9 @@ For this you need to first install pymol. Then in the top box you will find a te
 run /home/user/Repositories/traceratops/traceratops/pymol_script.py
 
 load_pdb_grid /home/user/data/outputs/PDBs
-  
+
 color_all_barcodes()
-  
+
 spin_grid
 ```
 
@@ -94,5 +94,3 @@ set grid_mode,1
 color green,  (name C*)
 color red, (name P*)
 ```
-
-

--- a/docs/source/scripts/trace/trace_plot.md
+++ b/docs/source/scripts/trace/trace_plot.md
@@ -11,17 +11,43 @@
 
 ## Examples
 
+### Export the first N traces
+
+By default, `trace_plot` exports a limited number of traces from the input trace
+file to PDB files. Use `--number_traces` (or `-n`) to choose how many traces to
+export. For example, this exports only the first 100 traces to the default
+`PDBs/` output folder:
+
+```bash
+$ trace_plot --input Trace_3D_barcode_KDtree_ROI:1.ecsv --number_traces 100
+```
+
+The output files are named after each exported `Trace_ID`.
+
+```bash
+$ trace_plot --input Trace_3D_barcode_KDtree_ROI:1.ecsv --number_traces 100 --output first_100_PDBs
+```
+
+this exports the first 100 traces to the folder `first_100_PDBs/`.
+
+### Export one selected trace
+
 ```bash
 $ ls Trace_3D_barcode_KDtree_ROI:1.ecsv | trace_plot --pipe --selected_trace 5b1e6f89-0362-4312-a7ed-fc55ae98a0a5
 ```
 
 this pipes the file 'Trace_3D_barcode_KDtree_ROI:1.ecsv' into trace_plot and then selects a trace for conversion.
 
+When `--selected_trace` is used, `--number_traces` is ignored.
+
+### Export all traces
+
 ```bash
 $ trace_plot --input Trace_3D_barcode_KDtree_ROI:1.ecsv --all
 ```
 
-this plots all traces in the trace file.
+this exports all traces in the trace file. When `--all` is used,
+`--number_traces` is ignored.
 
 
 

--- a/docs/source/scripts/trace/trace_plot.md
+++ b/docs/source/scripts/trace/trace_plot.md
@@ -50,6 +50,32 @@ this exports all traces in the trace file. When `--all` is used,
 `--number_traces` is ignored.
 
 
+## Visualizing traces in pymol
+
+`trace_plot` generates a folder with PDB files containing the 3D coordinates of the traces. Each barcode is assigned a different ATOM name, which is then used in pymol to color code barcodes. Instead, if the user provided a json dictionary (see section below), these are used as ATOM names.
+
+Once you generated the folder with the `PDB` files, it is time to load them in pymol.
+
+For this you need to first install pymol. Then in the top box you will find a terminal where you can write text, starting with `PyMOL> `. In this terminal you will write the following commands:
+
+
+```bash
+run /home/user/Repositories/traceratops/traceratops/pymol_script.py
+
+load_pdb_grid /home/user/data/outputs/PDBs
+  
+color_all_barcodes()
+  
+spin_grid
+```
+
+This assumes you have installed traceratops at `/home/user/Repositories/`. Otherwise select a different folder name.
+
+This also assumes your PDBs are in folder `/home/user/data/outputs/PDBs`, if they are in a different location correct accordingly.
+
+The first line will load the functions from a python script in traceratops. The second command will load 100 structures from the PDB file and represent them in a grid. The third line will color code each barcode with a different color. The final line will make the structures spin.
+
+If you want to colorcode your barcodes using a user defined code, see next section.
 
 ## Format for json dict
 
@@ -57,13 +83,10 @@ Please use the following format for the json dictionary to link barcode identiti
 
 ```{"12": "C  ", "18": "C  ", "9": "P  "}```
 
-keys provide barcode names in the trace file, these should be attributed to 3 character codes
+keys provide barcode names in the trace file, these should be attributed to 3 character codes. In this example, the barcode 12 is assigned the ATOM name `C`, barcode 18 is assigned `C` and atom 9 is assigned `P`. This provides a useful way of colorcoding your barcodes using a user defined coloring code.
 
 
-
-## pymol
-
-Some useful pymol commands:
+In this case you can run the first two lines of the script above in python (e.g. run ... and load_pdb_grid ...) and then apply separate colors for each barcode as follows as follows:
 
 
 ```
@@ -71,3 +94,5 @@ set grid_mode,1
 color green,  (name C*)
 color red, (name P*)
 ```
+
+

--- a/test/test_trace_plot.py
+++ b/test/test_trace_plot.py
@@ -1,0 +1,42 @@
+import os
+
+from traceratops.trace_plot import parse_arguments, create_dict_args, runtime
+
+TESTS_DIR = os.path.dirname(os.path.realpath(__file__))
+TRACE_FILE = os.path.join(
+    TESTS_DIR, "data", "trace_filter", "IN", "two_traces_seven_spots.ecsv"
+)
+
+
+def test_number_traces_exports_first_n_traces(tmp_path):
+    runtime(
+        trace_files=[TRACE_FILE],
+        folder_path=str(tmp_path),
+        select_traces="first",
+        number_traces=1,
+    )
+
+    generated = sorted(path.name for path in tmp_path.glob("*.pdb"))
+    assert generated == ["aaaaaaaa.pdb"]
+
+
+def test_number_traces_argument_selects_first_traces_mode():
+    parser = parse_arguments()
+    args = parser.parse_args(["--input", TRACE_FILE, "--number_traces", "1"])
+
+    parsed = create_dict_args(args)
+
+    assert parsed["number_traces"] == 1
+    assert parsed["select_traces"] == "first"
+
+
+def test_all_overrides_number_traces(tmp_path):
+    runtime(
+        trace_files=[TRACE_FILE],
+        folder_path=str(tmp_path),
+        select_traces="all",
+        number_traces=1,
+    )
+
+    generated = sorted(path.name for path in tmp_path.glob("*.pdb"))
+    assert generated == ["aaaaaaaa.pdb", "bbbbbbbb.pdb"]

--- a/test/test_trace_plot.py
+++ b/test/test_trace_plot.py
@@ -1,6 +1,6 @@
 import os
 
-from traceratops.trace_plot import parse_arguments, create_dict_args, runtime
+from traceratops.trace_plot import create_dict_args, parse_arguments, runtime
 
 TESTS_DIR = os.path.dirname(os.path.realpath(__file__))
 TRACE_FILE = os.path.join(

--- a/traceratops/trace_plot.py
+++ b/traceratops/trace_plot.py
@@ -26,7 +26,12 @@ from traceratops.script_banner import print_script_banner
 def parse_arguments():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--input", help="Name of input trace file.")
-    parser.add_argument("-n", "--number_traces", help="Number of traces treated")
+    parser.add_argument(
+        "-n",
+        "--number_traces",
+        help="Number of traces treated. Ignored when --all or --selected_trace is used.",
+        type=int,
+    )
     parser.add_argument(
         "-N", "--N_barcodes", help="minimum_number_barcodes. Default = 2"
     )
@@ -65,8 +70,10 @@ def create_dict_args(args):
     else:
         p["N_barcodes"] = 2
 
-    if args.number_traces:
-        p["number_traces"] = int(args.number_traces)
+    if args.number_traces is not None:
+        if args.number_traces < 1:
+            raise ValueError("--number_traces must be at least 1")
+        p["number_traces"] = args.number_traces
     else:
         p["number_traces"] = 2
 
@@ -82,8 +89,10 @@ def create_dict_args(args):
 
     if args.all:
         p["select_traces"] = "all"
-    else:
+    elif args.selected_trace:
         p["select_traces"] = "selected"
+    else:
+        p["select_traces"] = "first"
 
     p["trace_files"] = []
     if args.pipe:
@@ -108,13 +117,16 @@ def create_dict_args(args):
 
 def runtime(
     N_barcodes=2,
-    trace_files=[],
+    trace_files=None,
     selected_trace="fa9f0eb5-abcc-4730-bcc7-ba1da682d776",
-    barcode_type=dict(),
+    barcode_type=None,
     folder_path="./PDBs",
     select_traces="one",
+    number_traces=2,
 ):
     # gets trace files
+    trace_files = [] if trace_files is None else trace_files
+    barcode_type = {} if barcode_type is None else barcode_type
 
     if len(trace_files) > 0:
         print(
@@ -137,7 +149,16 @@ def runtime(
             # indexes traces by Trace_ID
             trace_table = trace.data
             trace_table_indexed = trace_table.group_by("Trace_ID")
-            print("$ number of traces to process: {}".format(len(trace_table_indexed)))
+            total_traces = len(trace_table_indexed.groups)
+            if select_traces == "first":
+                traces_to_process = min(number_traces, total_traces)
+            elif select_traces == "all":
+                traces_to_process = total_traces
+            else:
+                traces_to_process = 1
+
+            print(f"$ number of traces available: {total_traces}")
+            print(f"$ number of traces to process: {traces_to_process}")
 
             # iterates over traces
             for idx, single_trace in enumerate(trace_table_indexed.groups):
@@ -147,6 +168,8 @@ def runtime(
                 if select_traces == "selected" and trace_id == selected_trace:
                     flag = True
                 elif select_traces == "all":
+                    flag = True
+                elif select_traces == "first" and idx < number_traces:
                     flag = True
 
                 if flag:
@@ -191,6 +214,7 @@ def main():
         barcode_type=barcode_type,
         folder_path=folder_path,
         select_traces=p["select_traces"],
+        number_traces=p["number_traces"],
     )
 
     print(f"Processed <{n_traces_processed}> trace file(s)")

--- a/traceratops/trace_plot.py
+++ b/traceratops/trace_plot.py
@@ -4,12 +4,10 @@
 script to plot one or multiple traces in 3D
 
 Takes a trace file and either:
-    - ranks traces and plots a selection
-    - plots a user-selected trace in .ecsv (barcode, xyz) and PDF formats. The output files contain the trace name.
-    - saves output coordinates for selected traces in pdb format so they can be loaded by other means including https://www.rcsb.org/3d-view, pymol, or nglviewer.
-
-future:
-    - output PDBs for all the traces in a trace file
+    - exports the first N traces to PDB with --number_traces
+    - exports one trace to PDB with --selected_trace
+    - exports all traces to PDB with --all
+    - saves output coordinates for selected traces in PDB format so they can be loaded by other means including https://www.rcsb.org/3d-view, pymol, or nglviewer.
 """
 
 import argparse


### PR DESCRIPTION
### Motivation
- Calling `trace_plot` with `--number_traces N` produced no PDB outputs unless `--all` was used because the CLI and runtime used a "selected" mode by default that did not match any real trace IDs.
- Make `--number_traces` behave intuitively by exporting the first N traces when neither `--all` nor `--selected_trace` is provided.

### Description
- Parse `--number_traces` as an `int`, validate it is >= 1, and store it in the parsed arguments dictionary (`create_dict_args`).
- Add a new selection mode `first` when neither `--all` nor `--selected_trace` is passed, and make it the default selection mode when `--number_traces` is intended to be used.
- Propagate `number_traces` into `runtime()` and change the function signature to accept `trace_files=None` and `barcode_type=None` to avoid mutable default arguments.
- Implement first-N logic inside `runtime()` using `idx < number_traces`, report the total available traces and the number selected for processing, and leave `--all` and `--selected_trace` behaviors unchanged.
- Add regression tests in `test/test_trace_plot.py` that exercise (1) exporting the first N traces, (2) CLI parsing of `--number_traces`, and (3) that `--all` still overrides `--number_traces`.

### Testing
- Ran static compile checks with `python -m py_compile traceratops/trace_plot.py test/test_trace_plot.py`, which succeeded.
- Added `test/test_trace_plot.py` with three tests covering first-N export, CLI parsing, and `--all` precedence; these tests were created but could not be executed here due to missing runtime dependencies in the environment.
- Attempted to run `PYTHONPATH=. pytest -q test/test_trace_plot.py`, but test execution failed in this container because `matplotlib` is not installed; and `python -m pip install -e .` failed due to blocked package index access (network 403) when resolving build dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a55033a48208330b6d19a91639c809f)