### PR TITLE
Standardize localization tables on ECSV and deprecate .dat input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Localization tables now standardize on `.ecsv` outputs while keeping legacy `.dat` input support with a deprecation warning.
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),

--- a/docs/source/scripts/localization/collect_files.md
+++ b/docs/source/scripts/localization/collect_files.md
@@ -13,7 +13,7 @@
 When merging data from multiple ROIs, you need to collect one file per subdirectory
 into a single folder. Two problems arise:
 
-1. **Localization files** have the same name in every ROI (`localizations_3D_barcode.dat`),
+1. **Localization files** have the same name in every ROI (`localizations_3D_barcode.ecsv`),
    so they cannot be copied to the same folder without renaming.
 2. **Trace files** have different names (the ROI number varies), but you need to select
    only the right files and ignore others (e.g. Matrix files).
@@ -29,11 +29,11 @@ renamed by inserting the subdirectory name before the extension:
 
 ```bash
 collect_files --root data/RUT \
-    --example-file "localizations_3D_barcode.dat" \
+    --example-file "localizations_3D_barcode.ecsv" \
     --copy-to collected/
 ```
 
-Result: `localizations_3D_barcode_013_ROI.dat`, `localizations_3D_barcode_014_ROI.dat`, etc.
+Result: `localizations_3D_barcode_013_ROI.ecsv`, `localizations_3D_barcode_014_ROI.ecsv`, etc.
 
 ### Variable match (with `--variable-part`)
 
@@ -62,3 +62,7 @@ This matches `ROI-14.ecsv`, `ROI-25.ecsv`, etc. but rejects `ROI-021.ecsv`
 
 This script replaces the former `localization_cp_files` script and the `find -exec cp`
 pattern previously used for trace files.
+
+- Prefer `.ecsv` for localization tables. Legacy `.dat` localization inputs are
+  still readable for now, but traceratops warns that this support will be
+  discontinued in a future release.

--- a/docs/source/scripts/localization/localization_analyzer.md
+++ b/docs/source/scripts/localization/localization_analyzer.md
@@ -19,8 +19,10 @@ summary plot for the detected barcode localizations. The plot includes:
 - Roundness versus skew scatter plot, colored by barcode.
 
 The input table is read with `LocalizationTable.load`, so the script supports the
-same localization formats as the localization table reader, including `.ecsv`,
-`.dat`, and `.4dn` files.
+same localization formats as the localization table reader. Use `.ecsv` for
+localization tables; legacy `.dat` files still load for now but emit a
+deprecation warning because support will be discontinued in a future traceratops
+release. `.4dn` files are also supported.
 
 ## Usage examples
 

--- a/test/test_collect_files.py
+++ b/test/test_collect_files.py
@@ -21,7 +21,7 @@ from traceratops.collect_files import (
 
 EXAMPLE = "Trace_3D_barcode_mask-mask0_ROI-13.ecsv"
 VARPART = "13"
-LOC_EXAMPLE = "localizations_3D_barcode.dat"
+LOC_EXAMPLE = "localizations_3D_barcode.ecsv"
 
 
 def _make_tree(tmp_path: Path, layout: dict[str, list[str]]) -> Path:
@@ -249,11 +249,11 @@ class TestDestName:
         p = Path("/some/dir/data.ecsv")
         assert dest_name(p, "013_ROI", rename=True) == "data_013_ROI.ecsv"
 
-    def test_rename_dat(self):
-        p = Path("/x/localizations_3D_barcode.dat")
+    def test_rename_localization_ecsv(self):
+        p = Path("/x/localizations_3D_barcode.ecsv")
         assert (
             dest_name(p, "013_ROI", rename=True)
-            == "localizations_3D_barcode_013_ROI.dat"
+            == "localizations_3D_barcode_013_ROI.ecsv"
         )
 
 
@@ -495,8 +495,8 @@ class TestCollectFilesExactMode:
         copied = collect_files(root, LOC_EXAMPLE, dest)
 
         assert len(copied) == 2
-        assert (dest / "localizations_3D_barcode_013_ROI.dat").exists()
-        assert (dest / "localizations_3D_barcode_014_ROI.dat").exists()
+        assert (dest / "localizations_3D_barcode_013_ROI.ecsv").exists()
+        assert (dest / "localizations_3D_barcode_014_ROI.ecsv").exists()
 
     def test_preserves_content(self, tmp_path: Path):
         root = _make_tree(
@@ -509,7 +509,7 @@ class TestCollectFilesExactMode:
         dest = tmp_path / "output"
         collect_files(root, LOC_EXAMPLE, dest)
 
-        assert (dest / "localizations_3D_barcode_sub_a.dat").read_text() == (
+        assert (dest / "localizations_3D_barcode_sub_a.ecsv").read_text() == (
             "important data"
         )
 
@@ -521,7 +521,7 @@ class TestCollectFilesExactMode:
         )
         dest = tmp_path / "output"
         dest.mkdir()
-        (dest / "localizations_3D_barcode_sub_a.dat").write_text("old")
+        (dest / "localizations_3D_barcode_sub_a.ecsv").write_text("old")
 
         with pytest.raises(FileExistsError, match="collisions"):
             collect_files(root, LOC_EXAMPLE, dest)
@@ -530,7 +530,7 @@ class TestCollectFilesExactMode:
         """Exact match does not match similar but different filenames."""
         root = _make_tree(
             tmp_path,
-            {"sub_a": ["localizations_3D_barcode.dat.bak"]},
+            {"sub_a": ["localizations_3D_barcode.ecsv.bak"]},
         )
         dest = tmp_path / "output"
 
@@ -622,8 +622,8 @@ class TestMain:
             ]
         )
         assert code == 0
-        assert (dest / "localizations_3D_barcode_013_ROI.dat").exists()
-        assert (dest / "localizations_3D_barcode_014_ROI.dat").exists()
+        assert (dest / "localizations_3D_barcode_013_ROI.ecsv").exists()
+        assert (dest / "localizations_3D_barcode_014_ROI.ecsv").exists()
 
     def test_failure_exit_code(self, tmp_path: Path):
         root = _make_tree(

--- a/test/test_localization_table.py
+++ b/test/test_localization_table.py
@@ -1,3 +1,4 @@
+import pytest
 from astropy.table import Table
 
 from traceratops.core.localization_table import LocalizationTable
@@ -50,3 +51,71 @@ def test_plot_distribution_fluxes_skips_legacy_pyhim_table(tmp_path, capsys):
 
     assert "Please update pyHiM" in capsys.readouterr().out
     assert not output_path.exists()
+
+
+def _localization_table():
+    return Table(
+        rows=[
+            (
+                "1",
+                1,
+                1,
+                1,
+                "spot-1",
+                0.0,
+                0.0,
+                0.0,
+                5.0,
+                0.5,
+                0.1,
+                3,
+                1,
+                10.0,
+                20.0,
+                0.9,
+            )
+        ],
+        names=(
+            "Buid",
+            "ROI #",
+            "CellID #",
+            "Barcode #",
+            "id",
+            "zcentroid",
+            "xcentroid",
+            "ycentroid",
+            "snr",
+            "spot_pixel_percentage",
+            "skew",
+            "patch_size",
+            "object_class",
+            "mean_intensity",
+            "flux",
+            "roundness",
+        ),
+    )
+
+
+def test_load_dat_warns_about_legacy_extension(tmp_path, capsys):
+    path = tmp_path / "localizations_3D_barcode.dat"
+    _localization_table().write(path, format="ascii.ecsv")
+
+    with pytest.warns(FutureWarning, match=".dat extension are deprecated"):
+        table, barcodes = LocalizationTable().load(str(path))
+
+    assert len(table) == 1
+    assert list(barcodes) == [1]
+    assert (
+        "will be discontinued in a future traceratops release"
+        in capsys.readouterr().out
+    )
+
+
+def test_save_dat_extension_writes_ecsv_instead(tmp_path):
+    requested_path = tmp_path / "merged_localizations.dat"
+    actual_path = tmp_path / "merged_localizations.ecsv"
+
+    LocalizationTable().save(str(requested_path), _localization_table())
+
+    assert actual_path.exists()
+    assert not requested_path.exists()

--- a/traceratops/collect_files.py
+++ b/traceratops/collect_files.py
@@ -10,11 +10,11 @@ Two matching modes:
 **Exact match** (no ``--variable-part``)::
 
     collect_files --root data/RUT \\
-        --example-file "localizations_3D_barcode.dat" \\
+        --example-file "localizations_3D_barcode.ecsv" \\
         --copy-to collected/
 
 Files are automatically renamed with the subdirectory name
-(``localizations_3D_barcode_013_ROI.dat``) since they all share the
+(``localizations_3D_barcode_013_ROI.ecsv``) since they all share the
 same name.
 
 **Variable match** (with ``--variable-part``)::

--- a/traceratops/core/localization_table.py
+++ b/traceratops/core/localization_table.py
@@ -6,11 +6,40 @@ This class will contain methods to load, save, plot barcode localizations and st
 
 import os
 import sys
+import warnings
+from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from astropy.table import Table, vstack
+
+
+LEGACY_DAT_EXTENSION_WARNING = (
+    "Localization files with the .dat extension are deprecated and support "
+    "will be discontinued in a future traceratops release. Please rename or "
+    "save localization tables with the .ecsv extension."
+)
+
+
+def warn_legacy_dat_extension(file):
+    """Warn when a legacy ``.dat`` localization table is used as input."""
+    warnings.warn(LEGACY_DAT_EXTENSION_WARNING, FutureWarning, stacklevel=3)
+    print(f"WARNING: {LEGACY_DAT_EXTENSION_WARNING} File: {file}")
+
+
+def normalize_localization_output_path(file_name):
+    """Return an ECSV output path for non-4DN localization tables."""
+    path = Path(file_name)
+    if path.suffix.lower() == ".dat":
+        new_path = path.with_suffix(".ecsv")
+        print(
+            "WARNING: Saving localization tables with the .dat extension is "
+            "deprecated; writing ECSV output to "
+            f"{new_path} instead."
+        )
+        return str(new_path)
+    return str(path)
 
 
 class LocalizationTable:
@@ -184,6 +213,8 @@ class LocalizationTable:
 
         file_ext = os.path.splitext(file)[1].lower()
         if file_ext in (".ecsv", ".dat"):
+            if file_ext == ".dat":
+                warn_legacy_dat_extension(file)
             # print("$ Importing table from pyHiM format")
             barcode_map = read_table_from_ecsv(file)
             self.data = barcode_map
@@ -245,6 +276,7 @@ class LocalizationTable:
         if format == "4dn":
             self._convert_astropy_to_4dn(barcode_map, file_name)
         else:
+            file_name = normalize_localization_output_path(file_name)
             print(f"$ Saving output table as {file_name} ...")
             self.data = barcode_map
             self.remove_empty_comments()

--- a/traceratops/core/localization_table.py
+++ b/traceratops/core/localization_table.py
@@ -14,7 +14,6 @@ import numpy as np
 import pandas as pd
 from astropy.table import Table, vstack
 
-
 LEGACY_DAT_EXTENSION_WARNING = (
     "Localization files with the .dat extension are deprecated and support "
     "will be discontinued in a future traceratops release. Please rename or "


### PR DESCRIPTION
### Motivation
- Unify localization table handling so outputs are consistently ECSV while retaining temporary support for legacy `.dat` inputs.  
- Provide users with a clear deprecation path by emitting a warning when `.dat` localization files are loaded.

### Description
- Added a `LEGACY_DAT_EXTENSION_WARNING` and `warn_legacy_dat_extension()` helper that emits a `FutureWarning` and a visible warning when a `.dat` localization input is loaded.  
- Normalized save behavior in `LocalizationTable.save()` so requests to save as `.dat` are redirected to the corresponding `.ecsv` path and emit a warning via `normalize_localization_output_path()`.  
- Updated `LocalizationTable.load()` to call the warning helper when reading `.dat` inputs and preserved `.4dn` handling.  
- Updated tests, examples, documentation, and changelog entries to prefer `.ecsv` (including `collect_files` examples and tests) and added unit tests that verify the `.dat` load warning and that saving with a `.dat` filename produces an `.ecsv` file.

### Testing
- Ran `PYTHONPATH=. pytest -q test/test_collect_files.py`, which passed (`46 passed`).  
- Ran `python -m py_compile traceratops/core/localization_table.py traceratops/collect_files.py`, which completed successfully.  
- Attempted `PYTHONPATH=. pytest -q test/test_localization_table.py` but collection failed in this environment due to missing test dependency `astropy` (ModuleNotFoundError), so that test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a588674acfc833085c8ea8c81e50f43)