### PR TITLE
Add power-law fitting and improved plotting for physical-vs-genomic distances; add docs and test

### DIFF
--- a/docs/source/scripts/trace.md
+++ b/docs/source/scripts/trace.md
@@ -13,6 +13,7 @@
 - Filter Advanced ([trace_filter_advanced](trace/trace_filter_advanced.md))
 - Assign Mask ([trace_assign_mask](trace/trace_assign_mask.md))
 - Analyzer ([trace_analyzer](trace/trace_analyzer.md))
+- Physical vs Genomic Distance ([trace_physical_vs_genomic_distance](trace/trace_physical_vs_genomic_distance.md))
 - Compute and Plot 3-Way co-localization ([trace_3way_coloc](trace/trace_3way_coloc.md))
 
 ```{toctree}
@@ -32,5 +33,6 @@ trace/trace_export_to_fofct
 trace/trace_filter_advanced
 trace/trace_assign_mask
 trace/trace_analyzer
+trace/trace_physical_vs_genomic_distance
 trace/trace_3way_coloc
 ```

--- a/docs/source/scripts/trace/trace_physical_vs_genomic_distance.md
+++ b/docs/source/scripts/trace/trace_physical_vs_genomic_distance.md
@@ -1,0 +1,68 @@
+# trace_physical_vs_genomic_distance
+
+**Reliability status**: `development`
+
+`trace_physical_vs_genomic_distance.py` summarizes how physical chromatin-trace distances change with genomic separation. It reads a chromatin trace table, computes pairwise distances between all barcode loci in each trace, bins those distances by genomic distance, and writes a CSV table that can also be plotted as a log-log physical-vs-genomic-distance curve.
+
+```{eval-rst}
+.. argparse::
+   :ref: traceratops.trace_physical_vs_genomic_distance.parse_arguments
+   :prog: trace_physical_vs_genomic_distance
+```
+
+## What the script computes
+
+1. The script loads an input trace table supported by `ChromatinTraceTable` (`.ecsv`, `.dat`, `.4dn`, or `.csv`).
+2. Each trace is converted into a NumPy array with one row per trace, one column per barcode, and X/Y/Z coordinates in the final dimension.
+3. Genomic separation is computed from barcode midpoint positions, using `(Chrom_Start + Chrom_End) / 2`, and is reported in kilobase pairs (kbp).
+4. Physical pairwise distances are computed for:
+   - full 3D Euclidean distance, unless `--no_3d` is used;
+   - projected X-axis distance;
+   - projected Y-axis distance;
+   - projected Z-axis distance.
+5. Physical distances above `--dist_threshold` are replaced by `NaN` before summarization.
+6. Genomic distances are split into `--gen_dist_bins` equally spaced bins, and the median physical distance is reported for each bin and axis.
+
+## Output CSV columns
+
+The main output CSV contains one row per genomic-distance bin and axis:
+
+- `genomic distance (kbp)`: midpoint of the genomic-distance bin.
+- `log10 genomic dist (kbp)`: log10-transformed bin midpoint.
+- `median euclidean distance (nm)`: median physical distance for barcode pairs in the bin.
+- `log10 median dist (nm)`: log10-transformed median physical distance.
+- `n_data`: number of non-NaN physical distances used in the bin.
+- `experiment`: experiment label from `--experiment`, or `exp_None` when no label is supplied.
+- `axis`: one of `3D`, `X`, `Y`, or `Z`.
+
+If `--interloci_output` is supplied, the script also writes a CSV containing genomic distances between consecutive barcode loci.
+
+## Plot and power-law fit
+
+When `--plot` is provided, the script saves a stacked log-log plot with one panel per calculated axis. The x-axis is shared and shown only on the bottom panel, while a single shared y-axis label spans the panels to avoid label overlap.
+
+For every axis panel and experiment, the script fits the binned median distances to a power-law model:
+
+```text
+physical_distance = a * genomic_distance^b
+```
+
+The fit is performed by linear regression in log10 space. The plotted fit line is shown together with a 95% confidence interval for the fitted mean response. Each panel legend reports both fitted coefficients:
+
+- `a`: the scale coefficient.
+- `b`: the power-law exponent.
+
+## Example
+
+```bash
+trace_physical_vs_genomic_distance.py \
+  --input traces_KC_AB_merged.ecsv \
+  --output binned_physical_vs_genomic_distances.csv \
+  --interloci_output interloci_genomic_distances.csv \
+  --plot _physical_vs_genomic_plot.png \
+  --gen_dist_bins 50 \
+  --dist_threshold 1000 \
+  --experiment KC_AB
+```
+
+The plot filename is appended to the input stem by default. For the example above, the figure is saved as `traces_KC_AB_merged_physical_vs_genomic_plot.png`.

--- a/test/test_trace_physical_vs_genomic_distance.py
+++ b/test/test_trace_physical_vs_genomic_distance.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 from astropy.table import Table
 
 from traceratops.core.chromatin_trace_table import ChromatinTraceTable
@@ -7,6 +8,7 @@ from traceratops.trace_physical_vs_genomic_distance import (
     compute_all_pwd,
     compute_genomic_dist_map,
     extract_traces_numpy,
+    fit_power_law,
 )
 
 
@@ -59,3 +61,22 @@ def test_calculate_physical_vs_genomic_distance_writes_csv_outputs(tmp_path):
     assert output_file.is_file()
     assert interloci_file.is_file()
     assert set(result["axis"]) == {"3D", "X", "Y", "Z"}
+
+
+def test_fit_power_law_recovers_exponent_and_coefficient():
+    genomic_distance = np.array([1, 2, 4, 8, 16], dtype=float)
+    physical_distance = 3 * genomic_distance**0.5
+    fit = fit_power_law(
+        pd.DataFrame(
+            {
+                "genomic distance (kbp)": genomic_distance,
+                "median euclidean distance (nm)": physical_distance,
+            }
+        )
+    )
+
+    assert fit is not None
+    np.testing.assert_allclose(fit["coefficient"], 3, rtol=1e-12)
+    np.testing.assert_allclose(fit["exponent"], 0.5, rtol=1e-12)
+    assert np.all(fit["lower_log"] <= fit["y_fit_log"])
+    assert np.all(fit["upper_log"] >= fit["y_fit_log"])

--- a/traceratops/trace_physical_vs_genomic_distance.py
+++ b/traceratops/trace_physical_vs_genomic_distance.py
@@ -237,15 +237,13 @@ def plot_log_distance_graph(
             fit = fit_power_law(exp_df)
             if fit is None:
                 continue
-            color = palette.get(experiment)
             label = (
-                f"{experiment}: a={fit['coefficient']:.2g}, "
-                f"b={fit['exponent']:.3f}"
+                f"{experiment}: a={fit['coefficient']:.2g}, " f"b={fit['exponent']:.3f}"
             )
             ax.plot(
                 fit["x_fit_log"],
                 fit["y_fit_log"],
-                color=color,
+                color="r",
                 lw=1.2,
                 label=label,
             )
@@ -253,7 +251,7 @@ def plot_log_distance_graph(
                 fit["x_fit_log"],
                 fit["lower_log"],
                 fit["upper_log"],
-                color=color,
+                color="r",
                 alpha=0.18,
                 linewidth=0,
             )

--- a/traceratops/trace_physical_vs_genomic_distance.py
+++ b/traceratops/trace_physical_vs_genomic_distance.py
@@ -10,6 +10,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from astropy.table import unique
+from scipy import stats
 from scipy.spatial.distance import pdist
 from tqdm import tqdm
 
@@ -143,6 +144,59 @@ def compute_physical_vs_genomic_distance(
     return pd.DataFrame.from_records(records)
 
 
+def fit_power_law(
+    df: pd.DataFrame, confidence: float = 0.95, n_points: int = 200
+) -> Optional[Dict[str, np.ndarray]]:
+    """Fit ``physical_distance = coefficient * genomic_distance ** exponent``.
+
+    The fit is estimated by ordinary least squares in log10 space. Confidence
+    intervals describe the fitted mean response transformed back to linear space.
+    """
+    fit_df = df.dropna(
+        subset=["genomic distance (kbp)", "median euclidean distance (nm)"]
+    )
+    fit_df = fit_df.loc[
+        (fit_df["genomic distance (kbp)"] > 0)
+        & (fit_df["median euclidean distance (nm)"] > 0)
+    ]
+    if len(fit_df) < 3:
+        return None
+
+    x_log = np.log10(fit_df["genomic distance (kbp)"].to_numpy(dtype=float))
+    y_log = np.log10(fit_df["median euclidean distance (nm)"].to_numpy(dtype=float))
+    slope, intercept = np.polyfit(x_log, y_log, 1)
+
+    x_fit_log = np.linspace(np.nanmin(x_log), np.nanmax(x_log), n_points)
+    y_fit_log = intercept + slope * x_fit_log
+
+    residuals = y_log - (intercept + slope * x_log)
+    degrees_of_freedom = len(x_log) - 2
+    residual_std_error = np.sqrt(np.sum(residuals**2) / degrees_of_freedom)
+    x_mean = np.mean(x_log)
+    sum_squared_x = np.sum((x_log - x_mean) ** 2)
+    if sum_squared_x == 0:
+        return None
+    t_value = stats.t.ppf((1 + confidence) / 2, degrees_of_freedom)
+    mean_se = residual_std_error * np.sqrt(
+        (1 / len(x_log)) + ((x_fit_log - x_mean) ** 2 / sum_squared_x)
+    )
+
+    lower_log = y_fit_log - t_value * mean_se
+    upper_log = y_fit_log + t_value * mean_se
+    return {
+        "coefficient": 10**intercept,
+        "exponent": slope,
+        "x_fit": 10**x_fit_log,
+        "y_fit": 10**y_fit_log,
+        "lower": 10**lower_log,
+        "upper": 10**upper_log,
+        "x_fit_log": x_fit_log,
+        "y_fit_log": y_fit_log,
+        "lower_log": lower_log,
+        "upper_log": upper_log,
+    }
+
+
 def plot_log_distance_graph(
     dist_df: pd.DataFrame, saving_filename: Union[str, Path]
 ) -> None:
@@ -150,25 +204,71 @@ def plot_log_distance_graph(
     import seaborn as sns
 
     axes = [axis for axis in ["3D", "X", "Y", "Z"] if axis in set(dist_df["axis"])]
+    sns.set_context("paper")
     fig, axs = plt.subplots(
-        nrows=len(axes), ncols=1, squeeze=False, figsize=(8, 4 * len(axes))
+        nrows=len(axes),
+        ncols=1,
+        squeeze=False,
+        figsize=(6.5, 2.2 * len(axes)),
+        sharex=True,
+        constrained_layout=True,
+    )
+    palette = dict(
+        zip(
+            dist_df["experiment"].dropna().unique(),
+            sns.color_palette(n_colors=dist_df["experiment"].nunique()),
+        )
     )
     for row_index, axis_name in enumerate(axes):
+        ax = axs[row_index, 0]
         df = dist_df.loc[dist_df["axis"] == axis_name]
         sns.scatterplot(
             data=df,
             x="log10 genomic dist (kbp)",
             y="log10 median dist (nm)",
             hue="experiment",
-            ax=axs[row_index, 0],
+            palette=palette,
+            s=16,
+            linewidth=0,
+            legend=False,
+            ax=ax,
         )
-        axs[row_index, 0].set_title(axis_name)
-        if len(dist_df["experiment"].unique()) == 1:
-            legend = axs[row_index, 0].get_legend()
-            if legend is not None:
-                legend.remove()
+        for experiment, exp_df in df.groupby("experiment", dropna=False):
+            fit = fit_power_law(exp_df)
+            if fit is None:
+                continue
+            color = palette.get(experiment)
+            label = (
+                f"{experiment}: a={fit['coefficient']:.2g}, "
+                f"b={fit['exponent']:.3f}"
+            )
+            ax.plot(
+                fit["x_fit_log"],
+                fit["y_fit_log"],
+                color=color,
+                lw=1.2,
+                label=label,
+            )
+            ax.fill_between(
+                fit["x_fit_log"],
+                fit["lower_log"],
+                fit["upper_log"],
+                color=color,
+                alpha=0.18,
+                linewidth=0,
+            )
+        ax.set_title(axis_name, fontsize=11, pad=3)
+        ax.set_ylabel("")
+        ax.tick_params(axis="both", labelsize=9)
+        ax.legend(fontsize=7, frameon=False, loc="best")
+        if row_index < len(axes) - 1:
+            ax.set_xlabel("")
+            ax.tick_params(labelbottom=False)
+        else:
+            ax.set_xlabel("log10 genomic dist (kbp)", fontsize=10)
+    fig.supylabel("log10 median dist (nm)", fontsize=10)
     print(f"> Exporting figure to: {saving_filename}")
-    plt.savefig(saving_filename, dpi=100, bbox_inches="tight")
+    plt.savefig(saving_filename, dpi=150, bbox_inches="tight")
     plt.close(fig)
 
 


### PR DESCRIPTION
### Motivation
- Reduce figure label/legend overlap in the physical-vs-genomic-distance plot and make panels share axes to improve readability.
- Quantify the expected power-law dependence of physical distance on genomic separation by fitting a model and reporting coefficients.
- Document the new script behavior and provide a regression test that verifies the fit recovers known coefficients.

### Description
- Implemented `fit_power_law` in `traceratops/trace_physical_vs_genomic_distance.py` to fit `physical_distance = a * genomic_distance^b` in log10 space and return coefficient, exponent, fit curve and 95% confidence intervals.
- Updated `plot_log_distance_graph` to share the x-axis (`sharex=True`), show the x-label only on the bottom panel, use a single shared y-label, reduce marker/font sizes, use `constrained_layout`, and plot per-experiment power-law fits with confidence bands and legends showing `a` and `b`.
- Added documentation page `docs/source/scripts/trace/trace_physical_vs_genomic_distance.md` describing inputs, outputs, plotting, and the power-law fit, and linked it from `docs/source/scripts/trace.md`.
- Added a regression test `test_fit_power_law_recovers_exponent_and_coefficient` in `test/test_trace_physical_vs_genomic_distance.py` and updated imports to expose `fit_power_law`.

### Testing
- `python -m py_compile traceratops/trace_physical_vs_genomic_distance.py` ran successfully and reported no syntax errors (succeeded).
- `git diff --check` was run to validate whitespace and diff issues (succeeded).
- `pytest -q test/test_trace_physical_vs_genomic_distance.py` could not be executed in the environment because `numpy` was not available (failed to run due to missing dependency).
- `uv run pytest -q test/test_trace_physical_vs_genomic_distance.py` could not run because `uv.lock` parsing failed due to an inconsistent wheel entry (failed to run).
- `python -m pip install -e .` could not complete due to inability to fetch build dependencies from the package index (network/packaging failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5cb8c1cfd88330990d50c439693bc6)